### PR TITLE
Touch Sensor Callbacks

### DIFF
--- a/MPR121/MPR121.h
+++ b/MPR121/MPR121.h
@@ -8,6 +8,7 @@
 //
 // Changelog:
 // 2011-08-20 - initial release 
+// 2011-09-03 - add callback support
         
 /* ============================================
 I2Cdev device library code is placed under the MIT license
@@ -182,11 +183,19 @@ THE SOFTWARE.
 // these are suggested values from app note 3944
 #define TOUCH_THRESHOLD   0x0F
 #define RELEASE_THRESHOLD 0x0A
+#define NUM_CHANNELS      12
 
 class MPR121
 {
   public:
+    enum EventType {
+      TOUCHED    = 0,
+      RELEASED   = 1,
+      NUM_EVENTS = 2
+    };
   
+    typedef void (*CallbackPtrType)(void);
+    
     // constructor
     // takes a 7-b I2C address to use (0x5A by default, assumes addr pin grounded)
     MPR121(uint8_t address = MPR121_DEFAULT_ADDRESS);
@@ -202,8 +211,15 @@ class MPR121
     // when not given a channel, returns a bitfield of all touch channels.
     uint16_t getTouchStatus();
 
+    void setCallback(uint8_t channel, EventType event, CallbackPtrType callbackPtr);
+    
+    void serviceCallbacks();
+    
   private:
     uint8_t m_devAddr; // contains the I2C address of the device
+    CallbackPtrType m_callbackMap[NUM_CHANNELS][NUM_EVENTS];
+    bool m_prevTouchStatus[NUM_CHANNELS];
+    
 };
 
 #endif


### PR DESCRIPTION
Jeff,

I threw in basic callback support for the touch sensor.  You can register a void (void) callback to be invoked when the specified channel is touched, or released.  I may be adding some features, like a void (uint8_t) callback that will provide the channel number, or a void (uint8_t, bool) callback that will provide the channel number and whether the event was a touch (or a release).  I'm not sure I have a use case for these yet, though.

In general, would you prefer that I send pull requests when I reach a good stopping point on a feature (even if some parts are incomplete), or rather that I wait until I reach a major milestone, and submit pull requests more infrequently?  This is the first github project I have forked and have been contributing to, so I haven't a lot of experience with the best way to do things.

Also, I've been having some trouble with some of the updates you made (in support of Arduino 1.0 vs 022).  I'm running 022, but I didn't seem to get the mechanism (with the #defines) to work as I would have expected for selecting the version, and there seemed to be some trouble about selecting the right includes.  I've hacked up a version that works for me, but do you want me to follow up with it at all?

Thanks,
Andrew
