### PR TITLE
Add in new helper functions.  Correct error in ADS1115_OS_x

### DIFF
--- a/ADS1115/ADS1115.cpp
+++ b/ADS1115/ADS1115.cpp
@@ -7,6 +7,7 @@
 // Changelog:
 //     2011-08-02 - initial release
 //     2011-10-29 - added getDifferentialx() methods, F. Farzanegan
+//     2011-11-06 - added getVoltage, F. Farzanegan
 
 /* ============================================
 I2Cdev device library code is placed under the MIT license
@@ -220,6 +221,73 @@ int16_t ADS1115::getDiff3() {
     return getDifferential();
 }
 
+/** Get the current voltage reading
+ * Read the current differential and return it multiplied
+ * by the constant for the current gain.  mV is returned to
+ * increase the precision of the voltage
+ *
+ */
+float ADS1115::getMilliVolts() {
+  switch (pgaMode) {
+    case ADS1115_PGA_6P144:
+      return (getDifferential() * ADS1115_MV_6P144);
+      break;    
+    case ADS1115_PGA_4P096:
+      return (getDifferential() * ADS1115_MV_4P096);
+      break;             
+    case ADS1115_PGA_2P048:    
+      return (getDifferential() * ADS1115_MV_2P048);
+      break;       
+    case ADS1115_PGA_1P024:     
+      return (getDifferential() * ADS1115_MV_1P024);
+      break;       
+    case ADS1115_PGA_0P512:      
+      return (getDifferential() * ADS1115_MV_0P512);
+      break;       
+    case ADS1115_PGA_0P256:           
+    case ADS1115_PGA_0P256B:          
+    case ADS1115_PGA_0P256C:      
+      return (getDifferential() * ADS1115_MV_0P256);
+      break;       
+  }
+}
+
+/**
+ * Return the current multiplier for the PGA setting.
+ * 
+ * This may be directly retreived by using getMilliVolts(),
+ * but this causes an independent read.  This function could
+ * be used to average a number of reads from the getDifferential()
+ * or getDiffx(), or getDifferentialx() functions and cut down
+ * on the number of floating-point calculations needed.
+ *
+ */
+ 
+float ADS1115::getMvPerCount() {
+  switch (pgaMode) {
+    case ADS1115_PGA_6P144:
+      return ADS1115_MV_6P144;
+      break;    
+    case ADS1115_PGA_4P096:
+      return  ADS1115_MV_4P096;
+      break;             
+    case ADS1115_PGA_2P048:    
+      return ADS1115_MV_2P048;
+      break;       
+    case ADS1115_PGA_1P024:     
+      return ADS1115_MV_1P024;
+      break;       
+    case ADS1115_PGA_0P512:      
+      return ADS1115_MV_0P512;
+      break;       
+    case ADS1115_PGA_0P256:           
+    case ADS1115_PGA_0P256B:          
+    case ADS1115_PGA_0P256C:      
+      return ADS1115_MV_0P256;
+      break;       
+  }
+}
+
 // CONFIG register
 
 /** Get operational status.
@@ -295,7 +363,9 @@ uint8_t ADS1115::getGain() {
  * @see ADS1115_CFG_PGA_LENGTH
  */
 void ADS1115::setGain(uint8_t gain) {
-    I2Cdev::writeBitsW(devAddr, ADS1115_RA_CONFIG, ADS1115_CFG_PGA_BIT, ADS1115_CFG_PGA_LENGTH, gain);
+    if (I2Cdev::writeBitsW(devAddr, ADS1115_RA_CONFIG, ADS1115_CFG_PGA_BIT, ADS1115_CFG_PGA_LENGTH, gain)) {
+              pgaMode = gain;
+    }
 }
 /** Get device mode.
  * @return Current device mode

--- a/ADS1115/ADS1115.h
+++ b/ADS1115/ADS1115.h
@@ -6,6 +6,7 @@
 //
 // Changelog:
 //     2011-08-02 - initial release
+//     2011-10-29 - added getDifferentialx() methods, F. Farzanegan
 
 /* ============================================
 I2Cdev device library code is placed under the MIT license
@@ -61,8 +62,8 @@ THE SOFTWARE.
 #define ADS1115_CFG_COMP_QUE_BIT    1
 #define ADS1115_CFG_COMP_QUE_LENGTH 2
 
-#define ADS1115_OS_ACTIVE           0x00
-#define ADS1115_OS_INACTIVE         0x01
+#define ADS1115_OS_INACTIVE         0x00
+#define ADS1115_OS_ACTIVE           0x01
 
 #define ADS1115_MUX_P0_N1           0x00 // default
 #define ADS1115_MUX_P0_N3           0x01
@@ -81,6 +82,15 @@ THE SOFTWARE.
 #define ADS1115_PGA_0P256           0x05
 #define ADS1115_PGA_0P256B          0x06
 #define ADS1115_PGA_0P256C          0x07
+
+#define ADS1115_MV_6P144            0.187500
+#define ADS1115_MV_4P096            0.125000
+#define ADS1115_MV_2P048            0.062500 // default
+#define ADS1115_MV_1P024            0.031250
+#define ADS1115_MV_0P512            0.015625
+#define ADS1115_MV_0P256            0.007813
+#define ADS1115_MV_0P256B           0.007813 
+#define ADS1115_MV_0P256C           0.007813
 
 #define ADS1115_MODE_CONTINUOUS     0x00
 #define ADS1115_MODE_SINGLESHOT     0x01 // default
@@ -108,6 +118,7 @@ THE SOFTWARE.
 #define ADS1115_COMP_QUE_ASSERT4    0x02
 #define ADS1115_COMP_QUE_DISABLE    0x03 // default
 
+
 class ADS1115 {
     public:
         ADS1115();
@@ -126,6 +137,8 @@ class ADS1115 {
         int16_t getDiff1();
         int16_t getDiff2();
         int16_t getDiff3();
+        float getMilliVolts(); 
+        float getMvPerCount();
 
         // CONFIG register
         uint8_t getOpStatus();
@@ -158,6 +171,7 @@ class ADS1115 {
         uint16_t buffer[2];
         uint8_t devMode;
         uint8_t muxMode;
+        uint8_t pgaMode;
 };
 
 #endif /* _ADS1115_H_ */


### PR DESCRIPTION
New functions:
- getMilliVolts()
- getMvPerCount()

Add defined voltage values.

Set ADS1115_OS_ACTIVE to 0x01 (was swapped with inactive)
