### PR TITLE
Fixed return value for MPU6050::writeProgMemoryBlock()

### DIFF
--- a/MPU6050/MPU6050.cpp
+++ b/MPU6050/MPU6050.cpp
@@ -3018,7 +3018,7 @@ bool MPU6050::writeMemoryBlock(uint8_t *data, uint16_t dataSize, uint8_t bank, u
     return true;
 }
 bool MPU6050::writeProgMemoryBlock(uint8_t *data, uint16_t dataSize, uint8_t bank, uint8_t address, bool verify) {
-    writeMemoryBlock(data, dataSize, bank, address, verify, true);
+    return writeMemoryBlock(data, dataSize, bank, address, verify, true);
 }
 #define MPU6050_DMP_CONFIG_BLOCK_SIZE 6
 bool MPU6050::writeDMPConfigurationSet(uint8_t *data, uint16_t dataSize, bool useProgMem) {


### PR DESCRIPTION
This function was not returning a value, which apparently compiled (!?) and always returns a value that tests as false.  The demo program used the return value to test if the DMP program code had been written, and always assumed a failure.
