### PR TITLE
Fix issue when changing MUX or PGA, an invalid result is

### DIFF
--- a/Arduino/ADS1115/ADS1115.cpp
+++ b/Arduino/ADS1115/ADS1115.cpp
@@ -184,9 +184,6 @@ int16_t ADS1115::getConversionP2N3() {
     return getConversion();
 }
 
-
-
-
 /** Get AIN0/GND differential.
  * This changes the MUX setting to AIN0/GND if necessary, triggers a new
  * measurement (also only if necessary), then gets the differential value
@@ -239,7 +236,7 @@ int16_t ADS1115::getConversionP3GND() {
  *
  */
 float ADS1115::getMilliVolts() {
-  switch (pgaMode) {
+  switch (pgaMode) { 
     case ADS1115_PGA_6P144:
       return (getConversion() * ADS1115_MV_6P144);
       break;    
@@ -269,8 +266,8 @@ float ADS1115::getMilliVolts() {
  * This may be directly retreived by using getMilliVolts(),
  * but this causes an independent read.  This function could
  * be used to average a number of reads from the getConversion()
- * or getDiffx(), or getConversionx() functions and cut down
- * on the number of floating-point calculations needed.
+ * getConversionx() functions and cut downon the number of 
+ * floating-point calculations needed.
  *
  */
  
@@ -310,8 +307,7 @@ float ADS1115::getMvPerCount() {
  */
 uint8_t ADS1115::getOpStatus() {
     I2Cdev::readBitW(devAddr, ADS1115_RA_CONFIG, ADS1115_CFG_OS_BIT, buffer);
-    devMode=(uint8_t)buffer[0];
-    return devMode;
+    return (uint8_t)buffer[0];
 }
 /** Set operational status.
  * This bit can only be written while in power-down mode (no conversions active).
@@ -319,10 +315,8 @@ uint8_t ADS1115::getOpStatus() {
  * @see ADS1115_RA_CONFIG
  * @see ADS1115_CFG_OS_BIT
  */
-void ADS1115::setOpStatus(uint8_t status) {
-  
+void ADS1115::setOpStatus(uint8_t status) { 
     I2Cdev::writeBitW(devAddr, ADS1115_RA_CONFIG, ADS1115_CFG_OS_BIT, status);
-    devMode=status;
 }
 /** Get multiplexer connection.
  * @return Current multiplexer connection setting
@@ -335,7 +329,9 @@ uint8_t ADS1115::getMultiplexer() {
     muxMode = (uint8_t)buffer[0];
     return muxMode;
 }
-/** Set multiplexer connection.
+/** Set multiplexer connection.  Continous mode may fill the conversion register
+ * with data before the MUX setting has taken effect.  A stop/start of the conversion
+ * is done to reset the values.
  * @param mux New multiplexer connection setting
  * @see ADS1115_MUX_P0_N1
  * @see ADS1115_MUX_P0_N3
@@ -352,7 +348,14 @@ uint8_t ADS1115::getMultiplexer() {
 void ADS1115::setMultiplexer(uint8_t mux) {
     if (I2Cdev::writeBitsW(devAddr, ADS1115_RA_CONFIG, ADS1115_CFG_MUX_BIT, ADS1115_CFG_MUX_LENGTH, mux)) {
         muxMode = mux;
+        if (devMode == ADS1115_MODE_CONTINUOUS) {
+          // Force a stop/start
+          setMode(ADS1115_MODE_SINGLESHOT);
+          getConversion();
+          setMode(ADS1115_MODE_CONTINUOUS);
+        }
     }
+    
 }
 /** Get programmable gain amplifier level.
  * @return Current programmable gain amplifier level
@@ -365,7 +368,10 @@ uint8_t ADS1115::getGain() {
     pgaMode=(uint8_t)buffer[0];
     return pgaMode;
 }
-/** Set programmable gain amplifier level.
+/** Set programmable gain amplifier level.  
+ * Continous mode may fill the conversion register
+ * with data before the gain setting has taken effect.  A stop/start of the conversion
+ * is done to reset the values.
  * @param gain New programmable gain amplifier level
  * @see ADS1115_PGA_6P144
  * @see ADS1115_PGA_4P096
@@ -379,7 +385,13 @@ uint8_t ADS1115::getGain() {
  */
 void ADS1115::setGain(uint8_t gain) {
     if (I2Cdev::writeBitsW(devAddr, ADS1115_RA_CONFIG, ADS1115_CFG_PGA_BIT, ADS1115_CFG_PGA_LENGTH, gain)) {
-              pgaMode = gain;
+      pgaMode = gain;
+         if (devMode == ADS1115_MODE_CONTINUOUS) {
+            // Force a stop/start
+            setMode(ADS1115_MODE_SINGLESHOT);
+            getConversion();
+            setMode(ADS1115_MODE_CONTINUOUS);
+         }
     }
 }
 /** Get device mode.
@@ -414,7 +426,7 @@ void ADS1115::setMode(uint8_t mode) {
  */
 uint8_t ADS1115::getRate() {
     I2Cdev::readBitsW(devAddr, ADS1115_RA_CONFIG, ADS1115_CFG_DR_BIT, ADS1115_CFG_DR_LENGTH, buffer);
-    return buffer[0];
+    return (uint8_t)buffer[0];
 }
 /** Set data rate.
  * @param rate New data rate
@@ -442,7 +454,7 @@ void ADS1115::setRate(uint8_t rate) {
  */
 uint8_t ADS1115::getComparatorMode() {
     I2Cdev::readBitW(devAddr, ADS1115_RA_CONFIG, ADS1115_CFG_COMP_MODE_BIT, buffer);
-    return buffer[0];
+    return (uint8_t)buffer[0];
 }
 /** Set comparator mode.
  * @param mode New comparator mode
@@ -463,7 +475,7 @@ void ADS1115::setComparatorMode(uint8_t mode) {
  */
 uint8_t ADS1115::getComparatorPolarity() {
     I2Cdev::readBitW(devAddr, ADS1115_RA_CONFIG, ADS1115_CFG_COMP_POL_BIT, buffer);
-    return buffer[0];
+    return (uint8_t)buffer[0];
 }
 /** Set comparator polarity setting.
  * @param polarity New comparator polarity setting
@@ -508,7 +520,7 @@ void ADS1115::setComparatorLatchEnabled(bool enabled) {
  */
 uint8_t ADS1115::getComparatorQueueMode() {
     I2Cdev::readBitsW(devAddr, ADS1115_RA_CONFIG, ADS1115_CFG_COMP_QUE_BIT, ADS1115_CFG_COMP_QUE_LENGTH, buffer);
-    return buffer[0];
+    return (uint8_t)buffer[0];
 }
 /** Set comparator queue mode.
  * @param mode New comparator queue mode
@@ -558,7 +570,6 @@ void ADS1115::setHighThreshold(int16_t threshold) {
 }
 
 // Create a mask between two bits
-// http://stackoverflow.com/questions/8011700/how-do-i-extract-specific-n-bits-of-a-32-bit-unsigned-integer-in-c
 unsigned createMask(unsigned a, unsigned b)
 {
    unsigned mask = 0;

--- a/Arduino/ADS1115/ADS1115.h
+++ b/Arduino/ADS1115/ADS1115.h
@@ -140,9 +140,7 @@ class ADS1115 {
         bool testConnection();
         
         // SINGLE SHOT utilities
-        void startConversion(uint8_t channel, uint8_t pga_gain);
         void waitBusy(uint16_t max_retries);
-        int16_t getDiffSingle(uint8_t channel, uint8_t pga_gain, uint16_t max_retries);
 
         // Read the current CONVERSION register
         int16_t getConversion();
@@ -165,7 +163,7 @@ class ADS1115 {
 
         // CONFIG register
         uint8_t getOpStatus();
-        void setOpStatus(uint8_t mux);
+        void setOpStatus(uint8_t op);
         uint8_t getMultiplexer();
         void setMultiplexer(uint8_t mux);
         uint8_t getGain();

--- a/Arduino/ADS1115/Examples/ADS1115_differential/ADS1115_differential.ino
+++ b/Arduino/ADS1115/Examples/ADS1115_differential/ADS1115_differential.ino
@@ -1,0 +1,98 @@
+// I2C device class (I2Cdev) demonstration Arduino sketch for ADS1115 class
+// Example of reading two differential inputs of the ADS1115 and showing the value in mV
+// 06 May 2013 by Frederick Farzanegan (frederick1@farzanegan.org)
+// Updates should (hopefully) always be available at https://github.com/jrowberg/i2cdevlib
+//
+// Changelog:
+//     2013-05-13 - initial release
+
+/* ============================================
+I2Cdev device library code is placed under the MIT license
+Copyright (c) 2011 Jeff Rowberg
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+===============================================
+*/
+#include <Wire.h>
+#include "ADS1115.h"
+
+ADS1115 adc0(ADS1115_DEFAULT_ADDRESS); 
+
+void setup() {                
+    Wire.begin();  // join I2C bus
+    Serial.begin(19200); // initialize serial communication 
+    Serial.println("Initializing I2C devices..."); 
+    adc0.initialize(); // initialize ADS1115 16 bit A/D chip
+    
+    Serial.println("Testing device connections...");
+    Serial.println(adc0.testConnection() ? "ADS1115 connection successful" : "ADS1115 connection failed");
+      
+    // To get output from this method, you'll need to turn on the 
+    //#define ADS1115_SERIAL_DEBUG // in the ADS1115.h file
+    adc0.showConfigRegister();
+    
+    // We're going to do continuous sampling
+    adc0.setMode(ADS1115_MODE_CONTINUOUS);
+
+}
+
+void loop() 
+  {
+
+    // Sensor is on P0/N1 (pins 4/5)
+    Serial.println("Sensor 1 ************************");
+    // Set the gain (PGA) +/- 1.024v
+    adc0.setGain(ADS1115_PGA_1P024 );
+
+    // Get the number of counts of the accumulator
+    Serial.print("Counts for sensor 1 is:");
+    
+    // The below method sets the mux and gets a reading.
+    int sensorOneCounts=adc0.getConversionP0N1();  // counts up to 16-bits  
+    Serial.println(sensorOneCounts);
+
+    // To turn the counts into a voltage, we can use
+    Serial.print("Voltage for sensor 1 is:");
+    Serial.println(sensorOneCounts*adc0.getMvPerCount() );
+    
+    Serial.println();
+     
+     
+    // 2nd sensor is on P2/N3 (pins 6/7)
+    Serial.println("Sensor 2 ************************");
+    // Set the gain (PGA) +/- 0.256v
+    adc0.setGain(ADS1115_PGA_0P256);
+
+    // Manually set the MUX  // could have used the getConversionP* above
+    adc0.setMultiplexer(ADS1115_MUX_P2_N3); 
+    Serial.print("Counts for sensor 2 is:");
+    Serial.println(adc0.getConversion());  
+
+    Serial.print("mVoltage sensor 2 is:");
+    Serial.println(adc0.getMilliVolts());  // Convenience method to calculate voltage
+
+    Serial.println();
+    
+    delay(500);
+  }
+  
+
+  
+
+


### PR DESCRIPTION
in the conversion register.  Force a stop/start of the conversion
to clear the value.

Add an example sketch of reading from two different inputs with 
different gain values.
