### PR TITLE
Removed unnecessary endTransmission() after requestFrom() for "ARDUINO > 100".

### DIFF
--- a/Arduino/I2Cdev/I2Cdev.cpp
+++ b/Arduino/I2Cdev/I2Cdev.cpp
@@ -336,7 +336,7 @@ int8_t I2Cdev::readBytes(uint8_t devAddr, uint8_t regAddr, uint8_t length, uint8
  * @param length Number of words to read
  * @param data Buffer to store read data in
  * @param timeout Optional read timeout in milliseconds (0 to disable, leave off to use default class value in I2Cdev::readTimeout)
- * @return Number of words read (negaitve value indicates failure)
+ * @return Number of words read (negative value indicates failure)
  */
 int8_t I2Cdev::readWords(uint8_t devAddr, uint8_t regAddr, uint8_t length, uint16_t *data, uint16_t timeout) {
     #ifdef I2CDEV_SERIAL_DEBUG


### PR DESCRIPTION
Hi,

I'm new to Git, but I though this would be a good way to let you know the following: I've played around with the MPU-6050 and noticed unnecessary traffic when deciphering the I2C signal on my scope. I traced it to the endTransmission() lines now removed from readBytes() and readWords().

The requestFrom() in the Wire library reads the data to a buffer and sends a STOP on the I2C bus all in one go. The endTransmission() after that only sent a new START, address+w followed by STOP after receiving ACK on the address.

Hope this helps and thank you for MPU-6050 library.
