### PR TITLE
Update MPUTeapot.pde

### DIFF
--- a/Arduino/MPU6050/Examples/MPU6050_DMP6/Processing/MPUTeapot.pde
+++ b/Arduino/MPU6050/Examples/MPU6050_DMP6/Processing/MPUTeapot.pde
@@ -146,6 +146,7 @@ void serialEvent(Serial port) {
     while (port.available() > 0) {
         int ch = port.read();
         print((char)ch);
+        if (ch == '$') {serialCount = 0;} // this will help with alignment
         if (aligned < 4) {
             // make sure we are properly aligned on a 14-byte packet
             if (serialCount == 0) {


### PR DESCRIPTION
Without that update, the packets were not aligned. I understand that '$' can be part of incoming packet but without this line, aligned was always 0.
