### PR TITLE
PROGMEM compatibility for ARM Processors

### DIFF
--- a/Arduino/MPU6050/MPU6050.h
+++ b/Arduino/MPU6050/MPU6050.h
@@ -38,8 +38,18 @@ THE SOFTWARE.
 #define _MPU6050_H_
 
 #include "I2Cdev.h"
-//#include <avr/pgmspace.h>
 
+// supporting link:  http://forum.arduino.cc/index.php?&topic=143444.msg1079517#msg1079517
+// also: http://forum.arduino.cc/index.php?&topic=141571.msg1062899#msg1062899s
+#ifndef __arm__
+#include <avr/pgmspace.h>
+#else
+#define PROGMEM /* empty */
+#define pgm_read_byte(x) (*(x))
+#define pgm_read_word(x) (*(x))
+#define pgm_read_float(x) (*(x))
+#define PSTR(STR) STR
+#endif
 
 
 #define MPU6050_ADDRESS_AD0_LOW     0x68 // address pin low (GND), default for InvenSense evaluation board


### PR DESCRIPTION
Gets rid of ‘pgm_read_byte’ errors on ARM processors.
Tested to be working with Texas Instruments’ Tiva C Series Launchpad.
Backwards compatible with Arduino Uno (tested and working).
