### PR TITLE
Implement secondstime() already in header.

### DIFF
--- a/Arduino/DS1307/DS1307.cpp
+++ b/Arduino/DS1307/DS1307.cpp
@@ -456,11 +456,13 @@ void DS1307::setDateTime24(uint16_t year, uint8_t month, uint8_t day, uint8_t ho
     }
     
     uint32_t DateTime::unixtime(void) const {
+        return secondstime() + SECONDS_FROM_1970_TO_2000;
+    }
+    
+    long DateTime::secondstime(void) const {
         uint32_t t;
         uint16_t days = date2days(yOff, m, d);
-        t = time2long(days, hh, mm, ss);
-        t += SECONDS_FROM_1970_TO_2000;  // seconds from 1970 to 2000
-    
+        t = time2long(days, hh, mm, ss);    
         return t;
     }
 #endif


### PR DESCRIPTION
secondstime() is in DS1307.h, but wasn't implemented here. I'm a very new C++ programmer, so just make sure I haven't messed up anything with unixtime() converting a long into a uint32_t. (?)
