### PR TITLE
Set new mode immediately in HMC5843::setMode and HMC5883L::setMode

### DIFF
--- a/Arduino/HMC5843/HMC5843.cpp
+++ b/Arduino/HMC5843/HMC5843.cpp
@@ -227,7 +227,7 @@ void HMC5843::setMode(uint8_t newMode) {
     // use this method to guarantee that bits 7-2 are set to zero, which is a
     // requirement specified in the datasheet; it's actually more efficient than
     // using the I2Cdev.writeBits method
-    I2Cdev::writeByte(devAddr, HMC5843_RA_MODE, mode << (HMC5843_MODEREG_BIT - HMC5843_MODEREG_LENGTH + 1));
+    I2Cdev::writeByte(devAddr, HMC5843_RA_MODE, newMode << (HMC5843_MODEREG_BIT - HMC5843_MODEREG_LENGTH + 1));
     mode = newMode; // track to tell if we have to clear bit 7 after a read
 }
 

--- a/Arduino/HMC5883L/HMC5883L.cpp
+++ b/Arduino/HMC5883L/HMC5883L.cpp
@@ -250,7 +250,7 @@ void HMC5883L::setMode(uint8_t newMode) {
     // use this method to guarantee that bits 7-2 are set to zero, which is a
     // requirement specified in the datasheet; it's actually more efficient than
     // using the I2Cdev.writeBits method
-    I2Cdev::writeByte(devAddr, HMC5883L_RA_MODE, mode << (HMC5883L_MODEREG_BIT - HMC5883L_MODEREG_LENGTH + 1));
+    I2Cdev::writeByte(devAddr, HMC5883L_RA_MODE, newMode << (HMC5883L_MODEREG_BIT - HMC5883L_MODEREG_LENGTH + 1));
     mode = newMode; // track to tell if we have to clear bit 7 after a read
 }
 


### PR DESCRIPTION
It seems like setMode should set the new operating mod immediately
