### PR TITLE
Reading the motion detect status 

### DIFF
--- a/Arduino/MPU6050/MPU6050.cpp
+++ b/Arduino/MPU6050/MPU6050.cpp
@@ -34,7 +34,7 @@ THE SOFTWARE.
 ===============================================
 */
 
-#include "MPU6050.h"
+#include "MPU6050new.h"
 
 /** Default constructor, uses default I2C address.
  * @see MPU6050_DEFAULT_ADDRESS
@@ -2710,6 +2710,16 @@ uint8_t MPU6050::getDeviceID() {
 void MPU6050::setDeviceID(uint8_t id) {
     I2Cdev::writeBits(devAddr, MPU6050_RA_WHO_AM_I, MPU6050_WHO_AM_I_BIT, MPU6050_WHO_AM_I_LENGTH, id);
 }
+
+
+
+
+uint8_t MPU6050::getMotionStatus() {
+    I2Cdev::readBits(devAddr,MPU6050_RA_MOT_DETECT_STATUS,MPU6050_MOTION_MOT_XNEG_BIT,6,buffer);
+    return (buffer[0]);
+}
+
+
 
 // ======== UNDOCUMENTED/DMP REGISTERS/METHODS ========
 

--- a/Arduino/MPU6050/MPU6050.h
+++ b/Arduino/MPU6050/MPU6050.h
@@ -412,7 +412,7 @@ class MPU6050 {
     public:
         MPU6050();
         MPU6050(uint8_t address);
-
+	    uint8_t getMotionStatus();
         void initialize();
         bool testConnection();
 
@@ -987,6 +987,7 @@ class MPU6050 {
             uint32_t dmpGetAccelSumOfSquare();
             void dmpOverrideQuaternion(long *q);
             uint16_t dmpGetFIFOPacketSize();
+	    
         #endif
 
     private:


### PR DESCRIPTION
The previous way of reading the RA_MOT_DETECT_STATUS used  the readbit() function(getXPosMotionDetected()), therby erasing the rest of the motion detected bits(Once the interrupt register has been read, the entire register is reset). Therefore to get correct readigs the entire regiter has to be read at once. I have included a function (getMoitonStatus()) that reads the entire byte.
