### PR TITLE
fixed TCA6424A default address

### DIFF
--- a/Arduino/TCA6424A/TCA6424A.h
+++ b/Arduino/TCA6424A/TCA6424A.h
@@ -35,8 +35,8 @@ THE SOFTWARE.
 
 #include "I2Cdev.h"
 
-#define TCA6424A_ADDRESS_ADDR_LOW   0x34 // address pin low (GND)
-#define TCA6424A_ADDRESS_ADDR_HIGH  0x35 // address pin high (VCC)
+#define TCA6424A_ADDRESS_ADDR_LOW   0x22 // address pin low (GND)
+#define TCA6424A_ADDRESS_ADDR_HIGH  0x23 // address pin high (VCC)
 #define TCA6424A_DEFAULT_ADDRESS    TCA6424A_ADDRESS_ADDR_LOW
 
 #define TCA6424A_RA_INPUT0          0x00


### PR DESCRIPTION
Hello
I just fixed default TCA6424A address. Old was 0x34 which is not correct.
Best regards
