### PR TITLE
PlatformIO Library Registry manifest file

### DIFF
--- a/Arduino/MPU6050/library.json
+++ b/Arduino/MPU6050/library.json
@@ -1,0 +1,18 @@
+{
+  "name": "I2Cdevlib-MPU6050",
+  "keywords": "gyroscope, accelerometer, sensor, i2cdevlib, i2c",
+  "description": "The MPU6050 combines a 3-axis gyroscope and a 3-axis accelerometer on the same silicon die together with an onboard Digital Motion Processor(DMP) which processes complex 6-axis MotionFusion algorithms",
+  "include": "Arduino/MPU6050",
+  "repository":
+  {
+    "type": "git",
+    "url": "https://github.com/jrowberg/i2cdevlib.git"
+  },
+  "dependencies":
+  {
+    "name": "I2Cdevlib-Core",
+    "frameworks": "arduino"
+  },
+  "frameworks": "arduino",
+  "platforms": "atmelavr"
+}


### PR DESCRIPTION
- This library in Web Registry: http://platformio.ikravets.com/#!/lib/show/107/I2Cdevlib-MPU6050
- Specification: [PlatformIO Library Manager](http://docs.platformio.ikravets.com/en/latest/librarymanager/index.html)
- Integration: [IDE Integration](http://docs.platformio.ikravets.com/en/latest/ide.html)
