### PR TITLE
Add 'out of the box' support for Spark Core devices (arduino compatible)

### DIFF
--- a/Arduino/I2Cdev/I2Cdev.h
+++ b/Arduino/I2Cdev/I2Cdev.h
@@ -84,6 +84,11 @@ THE SOFTWARE.
     #endif
 #endif
 
+#ifdef SPARK
+    #include <spark_wiring_i2c.h>
+    #define ARDUINO 101
+#endif
+
 // 1000ms default read timeout (modify with "I2Cdev::readTimeout = [ms];")
 #define I2CDEV_DEFAULT_READ_TIMEOUT     1000
 


### PR DESCRIPTION
The Spark Core family of devices (https://spark.io) come with an Arduino 1.0.1+ compatible `Wire` implementation.

Although the Spark Core is fully Arduino compatible, it doesn't `#define ARDUINO` instead it does `#define SPARK`. 

This change makes i2cdevlib safely compatible with Spark Core devices out of the box, and I have extensively tested it with the stock MPU6050 library.