### PR TITLE
Allows setting I2CDEV_IMPLEMENTATION externally.

### DIFF
--- a/Arduino/I2Cdev/I2Cdev.h
+++ b/Arduino/I2Cdev/I2Cdev.h
@@ -49,8 +49,10 @@ THE SOFTWARE.
 // -----------------------------------------------------------------------------
 // I2C interface implementation setting
 // -----------------------------------------------------------------------------
+#ifndef I2CDEV_IMPLEMENTATION
 #define I2CDEV_IMPLEMENTATION       I2CDEV_ARDUINO_WIRE
 //#define I2CDEV_IMPLEMENTATION       I2CDEV_BUILTIN_FASTWIRE
+#endif // I2CDEV_IMPLEMENTATION
 
 // comment this out if you are using a non-optimal IDE/implementation setting
 // but want the compiler to shut up about it


### PR DESCRIPTION
This way, it's not necessary to modify I2Cdev.h every time the project is cloned/pulled, and it allows for compile-time tools to switch which implementation is used.