### PR TITLE
Small BMP085 fixes.

### DIFF
--- a/Arduino/BMP085/BMP085.h
+++ b/Arduino/BMP085/BMP085.h
@@ -79,6 +79,7 @@ class BMP085 {
         void initialize();
         bool testConnection();
 
+#ifdef BMP085_INCLUDE_INDIVIDUAL_CALIBRATION_ACCESS
         /* calibration register methods */
         int16_t     getAC1();
         int16_t     getAC2();
@@ -91,6 +92,7 @@ class BMP085 {
         int16_t     getMB();
         int16_t     getMC();
         int16_t     getMD();
+#endif
 
         /* CONTROL register methods */
         uint8_t     getControl();
@@ -113,7 +115,7 @@ class BMP085 {
 
    private:
         uint8_t devAddr;
-        uint8_t buffer[2];
+        uint8_t buffer[3];
 
         bool calibrationLoaded;
         int16_t ac1, ac2, ac3, b1, b2, mb, mc, md;


### PR DESCRIPTION
Bumped BMP085 private buffer up to 3 bytes, for getMeasurement3().

Protected the definition of calibration methods by the same #ifdef as the code
has, so people browsing the header files won't be too surprised.