### PR TITLE
Fix for 32bit MPU6050::dmpGetAccel, MPU6050::dmpGetQuaternion and MPU6050::dmpGetGyro

### DIFF
--- a/Arduino/MPU6050/MPU6050_6Axis_MotionApps20.h
+++ b/Arduino/MPU6050/MPU6050_6Axis_MotionApps20.h
@@ -577,9 +577,9 @@ bool MPU6050::dmpPacketAvailable() {
 uint8_t MPU6050::dmpGetAccel(int32_t *data, const uint8_t* packet) {
     // TODO: accommodate different arrangements of sent data (ONLY default supported now)
     if (packet == 0) packet = dmpPacketBuffer;
-    data[0] = ((packet[28] << 24) + (packet[29] << 16) + (packet[30] << 8) + packet[31]);
-    data[1] = ((packet[32] << 24) + (packet[33] << 16) + (packet[34] << 8) + packet[35]);
-    data[2] = ((packet[36] << 24) + (packet[37] << 16) + (packet[38] << 8) + packet[39]);
+    data[0] = (((uint32_t)packet[28] << 24) + ((uint32_t)packet[29] << 16) + ((uint32_t)packet[30] << 8) + packet[31]);
+    data[1] = (((uint32_t)packet[32] << 24) + ((uint32_t)packet[33] << 16) + ((uint32_t)packet[34] << 8) + packet[35]);
+    data[2] = (((uint32_t)packet[36] << 24) + ((uint32_t)packet[37] << 16) + ((uint32_t)packet[38] << 8) + packet[39]);
     return 0;
 }
 uint8_t MPU6050::dmpGetAccel(int16_t *data, const uint8_t* packet) {
@@ -601,10 +601,10 @@ uint8_t MPU6050::dmpGetAccel(VectorInt16 *v, const uint8_t* packet) {
 uint8_t MPU6050::dmpGetQuaternion(int32_t *data, const uint8_t* packet) {
     // TODO: accommodate different arrangements of sent data (ONLY default supported now)
     if (packet == 0) packet = dmpPacketBuffer;
-    data[0] = ((packet[0] << 24) + (packet[1] << 16) + (packet[2] << 8) + packet[3]);
-    data[1] = ((packet[4] << 24) + (packet[5] << 16) + (packet[6] << 8) + packet[7]);
-    data[2] = ((packet[8] << 24) + (packet[9] << 16) + (packet[10] << 8) + packet[11]);
-    data[3] = ((packet[12] << 24) + (packet[13] << 16) + (packet[14] << 8) + packet[15]);
+    data[0] = (((uint32_t)packet[0] << 24) + ((uint32_t)packet[1] << 16) + ((uint32_t)packet[2] << 8) + packet[3]);
+    data[1] = (((uint32_t)packet[4] << 24) + ((uint32_t)packet[5] << 16) + ((uint32_t)packet[6] << 8) + packet[7]);
+    data[2] = (((uint32_t)packet[8] << 24) + ((uint32_t)packet[9] << 16) + ((uint32_t)packet[10] << 8) + packet[11]);
+    data[3] = (((uint32_t)packet[12] << 24) + ((uint32_t)packet[13] << 16) + ((uint32_t)packet[14] << 8) + packet[15]);
     return 0;
 }
 uint8_t MPU6050::dmpGetQuaternion(int16_t *data, const uint8_t* packet) {
@@ -634,9 +634,9 @@ uint8_t MPU6050::dmpGetQuaternion(Quaternion *q, const uint8_t* packet) {
 uint8_t MPU6050::dmpGetGyro(int32_t *data, const uint8_t* packet) {
     // TODO: accommodate different arrangements of sent data (ONLY default supported now)
     if (packet == 0) packet = dmpPacketBuffer;
-    data[0] = ((packet[16] << 24) + (packet[17] << 16) + (packet[18] << 8) + packet[19]);
-    data[1] = ((packet[20] << 24) + (packet[21] << 16) + (packet[22] << 8) + packet[23]);
-    data[2] = ((packet[24] << 24) + (packet[25] << 16) + (packet[26] << 8) + packet[27]);
+    data[0] = (((uint32_t)packet[16] << 24) + ((uint32_t)packet[17] << 16) + ((uint32_t)packet[18] << 8) + packet[19]);
+    data[1] = (((uint32_t)packet[20] << 24) + ((uint32_t)packet[21] << 16) + ((uint32_t)packet[22] << 8) + packet[23]);
+    data[2] = (((uint32_t)packet[24] << 24) + ((uint32_t)packet[25] << 16) + ((uint32_t)packet[26] << 8) + packet[27]);
     return 0;
 }
 uint8_t MPU6050::dmpGetGyro(int16_t *data, const uint8_t* packet) {

--- a/Arduino/MPU6050/MPU6050_6Axis_MotionApps20.h
+++ b/Arduino/MPU6050/MPU6050_6Axis_MotionApps20.h
@@ -577,43 +577,43 @@ bool MPU6050::dmpPacketAvailable() {
 uint8_t MPU6050::dmpGetAccel(int32_t *data, const uint8_t* packet) {
     // TODO: accommodate different arrangements of sent data (ONLY default supported now)
     if (packet == 0) packet = dmpPacketBuffer;
-    data[0] = (((uint32_t)packet[28] << 24) + ((uint32_t)packet[29] << 16) + ((uint32_t)packet[30] << 8) + packet[31]);
-    data[1] = (((uint32_t)packet[32] << 24) + ((uint32_t)packet[33] << 16) + ((uint32_t)packet[34] << 8) + packet[35]);
-    data[2] = (((uint32_t)packet[36] << 24) + ((uint32_t)packet[37] << 16) + ((uint32_t)packet[38] << 8) + packet[39]);
+    data[0] = (((uint32_t)packet[28] << 24) | ((uint32_t)packet[29] << 16) | ((uint32_t)packet[30] << 8) | packet[31]);
+    data[1] = (((uint32_t)packet[32] << 24) | ((uint32_t)packet[33] << 16) | ((uint32_t)packet[34] << 8) | packet[35]);
+    data[2] = (((uint32_t)packet[36] << 24) | ((uint32_t)packet[37] << 16) | ((uint32_t)packet[38] << 8) | packet[39]);
     return 0;
 }
 uint8_t MPU6050::dmpGetAccel(int16_t *data, const uint8_t* packet) {
     // TODO: accommodate different arrangements of sent data (ONLY default supported now)
     if (packet == 0) packet = dmpPacketBuffer;
-    data[0] = (packet[28] << 8) + packet[29];
-    data[1] = (packet[32] << 8) + packet[33];
-    data[2] = (packet[36] << 8) + packet[37];
+    data[0] = (packet[28] << 8) | packet[29];
+    data[1] = (packet[32] << 8) | packet[33];
+    data[2] = (packet[36] << 8) | packet[37];
     return 0;
 }
 uint8_t MPU6050::dmpGetAccel(VectorInt16 *v, const uint8_t* packet) {
     // TODO: accommodate different arrangements of sent data (ONLY default supported now)
     if (packet == 0) packet = dmpPacketBuffer;
-    v -> x = (packet[28] << 8) + packet[29];
-    v -> y = (packet[32] << 8) + packet[33];
-    v -> z = (packet[36] << 8) + packet[37];
+    v -> x = (packet[28] << 8) | packet[29];
+    v -> y = (packet[32] << 8) | packet[33];
+    v -> z = (packet[36] << 8) | packet[37];
     return 0;
 }
 uint8_t MPU6050::dmpGetQuaternion(int32_t *data, const uint8_t* packet) {
     // TODO: accommodate different arrangements of sent data (ONLY default supported now)
     if (packet == 0) packet = dmpPacketBuffer;
-    data[0] = (((uint32_t)packet[0] << 24) + ((uint32_t)packet[1] << 16) + ((uint32_t)packet[2] << 8) + packet[3]);
-    data[1] = (((uint32_t)packet[4] << 24) + ((uint32_t)packet[5] << 16) + ((uint32_t)packet[6] << 8) + packet[7]);
-    data[2] = (((uint32_t)packet[8] << 24) + ((uint32_t)packet[9] << 16) + ((uint32_t)packet[10] << 8) + packet[11]);
-    data[3] = (((uint32_t)packet[12] << 24) + ((uint32_t)packet[13] << 16) + ((uint32_t)packet[14] << 8) + packet[15]);
+    data[0] = (((uint32_t)packet[0] << 24) | ((uint32_t)packet[1] << 16) | ((uint32_t)packet[2] << 8) | packet[3]);
+    data[1] = (((uint32_t)packet[4] << 24) | ((uint32_t)packet[5] << 16) | ((uint32_t)packet[6] << 8) | packet[7]);
+    data[2] = (((uint32_t)packet[8] << 24) | ((uint32_t)packet[9] << 16) | ((uint32_t)packet[10] << 8) | packet[11]);
+    data[3] = (((uint32_t)packet[12] << 24) | ((uint32_t)packet[13] << 16) | ((uint32_t)packet[14] << 8) | packet[15]);
     return 0;
 }
 uint8_t MPU6050::dmpGetQuaternion(int16_t *data, const uint8_t* packet) {
     // TODO: accommodate different arrangements of sent data (ONLY default supported now)
     if (packet == 0) packet = dmpPacketBuffer;
-    data[0] = ((packet[0] << 8) + packet[1]);
-    data[1] = ((packet[4] << 8) + packet[5]);
-    data[2] = ((packet[8] << 8) + packet[9]);
-    data[3] = ((packet[12] << 8) + packet[13]);
+    data[0] = ((packet[0] << 8) | packet[1]);
+    data[1] = ((packet[4] << 8) | packet[5]);
+    data[2] = ((packet[8] << 8) | packet[9]);
+    data[3] = ((packet[12] << 8) | packet[13]);
     return 0;
 }
 uint8_t MPU6050::dmpGetQuaternion(Quaternion *q, const uint8_t* packet) {
@@ -634,25 +634,25 @@ uint8_t MPU6050::dmpGetQuaternion(Quaternion *q, const uint8_t* packet) {
 uint8_t MPU6050::dmpGetGyro(int32_t *data, const uint8_t* packet) {
     // TODO: accommodate different arrangements of sent data (ONLY default supported now)
     if (packet == 0) packet = dmpPacketBuffer;
-    data[0] = (((uint32_t)packet[16] << 24) + ((uint32_t)packet[17] << 16) + ((uint32_t)packet[18] << 8) + packet[19]);
-    data[1] = (((uint32_t)packet[20] << 24) + ((uint32_t)packet[21] << 16) + ((uint32_t)packet[22] << 8) + packet[23]);
-    data[2] = (((uint32_t)packet[24] << 24) + ((uint32_t)packet[25] << 16) + ((uint32_t)packet[26] << 8) + packet[27]);
+    data[0] = (((uint32_t)packet[16] << 24) | ((uint32_t)packet[17] << 16) | ((uint32_t)packet[18] << 8) | packet[19]);
+    data[1] = (((uint32_t)packet[20] << 24) | ((uint32_t)packet[21] << 16) | ((uint32_t)packet[22] << 8) | packet[23]);
+    data[2] = (((uint32_t)packet[24] << 24) | ((uint32_t)packet[25] << 16) | ((uint32_t)packet[26] << 8) | packet[27]);
     return 0;
 }
 uint8_t MPU6050::dmpGetGyro(int16_t *data, const uint8_t* packet) {
     // TODO: accommodate different arrangements of sent data (ONLY default supported now)
     if (packet == 0) packet = dmpPacketBuffer;
-    data[0] = (packet[16] << 8) + packet[17];
-    data[1] = (packet[20] << 8) + packet[21];
-    data[2] = (packet[24] << 8) + packet[25];
+    data[0] = (packet[16] << 8) | packet[17];
+    data[1] = (packet[20] << 8) | packet[21];
+    data[2] = (packet[24] << 8) | packet[25];
     return 0;
 }
 uint8_t MPU6050::dmpGetGyro(VectorInt16 *v, const uint8_t* packet) {
     // TODO: accommodate different arrangements of sent data (ONLY default supported now)
     if (packet == 0) packet = dmpPacketBuffer;
-    v -> x = (packet[16] << 8) + packet[17];
-    v -> y = (packet[20] << 8) + packet[21];
-    v -> z = (packet[24] << 8) + packet[25];
+    v -> x = (packet[16] << 8) | packet[17];
+    v -> y = (packet[20] << 8) | packet[21];
+    v -> z = (packet[24] << 8) | packet[25];
     return 0;
 }
 // uint8_t MPU6050::dmpSetLinearAccelFilterCoefficient(float coef);

--- a/Arduino/MPU6050/MPU6050_9Axis_MotionApps41.h
+++ b/Arduino/MPU6050/MPU6050_9Axis_MotionApps41.h
@@ -680,9 +680,9 @@ bool MPU6050::dmpPacketAvailable() {
 uint8_t MPU6050::dmpGetAccel(int32_t *data, const uint8_t* packet) {
     // TODO: accommodate different arrangements of sent data (ONLY default supported now)
     if (packet == 0) packet = dmpPacketBuffer;
-    data[0] = ((packet[34] << 24) + (packet[35] << 16) + (packet[36] << 8) + packet[37]);
-    data[1] = ((packet[38] << 24) + (packet[39] << 16) + (packet[40] << 8) + packet[41]);
-    data[2] = ((packet[42] << 24) + (packet[43] << 16) + (packet[44] << 8) + packet[45]);
+    data[0] = (((uint32_t)packet[34] << 24) + ((uint32_t)packet[35] << 16) + ((uint32_t)packet[36] << 8) + packet[37]);
+    data[1] = (((uint32_t)packet[38] << 24) + ((uint32_t)packet[39] << 16) + ((uint32_t)packet[40] << 8) + packet[41]);
+    data[2] = (((uint32_t)packet[42] << 24) + ((uint32_t)packet[43] << 16) + ((uint32_t)packet[44] << 8) + packet[45]);
     return 0;
 }
 uint8_t MPU6050::dmpGetAccel(int16_t *data, const uint8_t* packet) {
@@ -704,10 +704,10 @@ uint8_t MPU6050::dmpGetAccel(VectorInt16 *v, const uint8_t* packet) {
 uint8_t MPU6050::dmpGetQuaternion(int32_t *data, const uint8_t* packet) {
     // TODO: accommodate different arrangements of sent data (ONLY default supported now)
     if (packet == 0) packet = dmpPacketBuffer;
-    data[0] = ((packet[0] << 24) + (packet[1] << 16) + (packet[2] << 8) + packet[3]);
-    data[1] = ((packet[4] << 24) + (packet[5] << 16) + (packet[6] << 8) + packet[7]);
-    data[2] = ((packet[8] << 24) + (packet[9] << 16) + (packet[10] << 8) + packet[11]);
-    data[3] = ((packet[12] << 24) + (packet[13] << 16) + (packet[14] << 8) + packet[15]);
+    data[0] = (((uint32_t)packet[0] << 24) + ((uint32_t)packet[1] << 16) + ((uint32_t)packet[2] << 8) + packet[3]);
+    data[1] = (((uint32_t)packet[4] << 24) + ((uint32_t)packet[5] << 16) + ((uint32_t)packet[6] << 8) + packet[7]);
+    data[2] = (((uint32_t)packet[8] << 24) + ((uint32_t)packet[9] << 16) + ((uint32_t)packet[10] << 8) + packet[11]);
+    data[3] = (((uint32_t)packet[12] << 24) + ((uint32_t)packet[13] << 16) + ((uint32_t)packet[14] << 8) + packet[15]);
     return 0;
 }
 uint8_t MPU6050::dmpGetQuaternion(int16_t *data, const uint8_t* packet) {
@@ -737,9 +737,9 @@ uint8_t MPU6050::dmpGetQuaternion(Quaternion *q, const uint8_t* packet) {
 uint8_t MPU6050::dmpGetGyro(int32_t *data, const uint8_t* packet) {
     // TODO: accommodate different arrangements of sent data (ONLY default supported now)
     if (packet == 0) packet = dmpPacketBuffer;
-    data[0] = ((packet[16] << 24) + (packet[17] << 16) + (packet[18] << 8) + packet[19]);
-    data[1] = ((packet[20] << 24) + (packet[21] << 16) + (packet[22] << 8) + packet[23]);
-    data[2] = ((packet[24] << 24) + (packet[25] << 16) + (packet[26] << 8) + packet[27]);
+    data[0] = (((uint32_t)packet[16] << 24) + ((uint32_t)packet[17] << 16) + ((uint32_t)packet[18] << 8) + packet[19]);
+    data[1] = (((uint32_t)packet[20] << 24) + ((uint32_t)packet[21] << 16) + ((uint32_t)packet[22] << 8) + packet[23]);
+    data[2] = (((uint32_t)packet[24] << 24) + ((uint32_t)packet[25] << 16) + ((uint32_t)packet[26] << 8) + packet[27]);
     return 0;
 }
 uint8_t MPU6050::dmpGetGyro(int16_t *data, const uint8_t* packet) {

--- a/Arduino/MPU6050/MPU6050_9Axis_MotionApps41.h
+++ b/Arduino/MPU6050/MPU6050_9Axis_MotionApps41.h
@@ -680,43 +680,43 @@ bool MPU6050::dmpPacketAvailable() {
 uint8_t MPU6050::dmpGetAccel(int32_t *data, const uint8_t* packet) {
     // TODO: accommodate different arrangements of sent data (ONLY default supported now)
     if (packet == 0) packet = dmpPacketBuffer;
-    data[0] = (((uint32_t)packet[34] << 24) + ((uint32_t)packet[35] << 16) + ((uint32_t)packet[36] << 8) + packet[37]);
-    data[1] = (((uint32_t)packet[38] << 24) + ((uint32_t)packet[39] << 16) + ((uint32_t)packet[40] << 8) + packet[41]);
-    data[2] = (((uint32_t)packet[42] << 24) + ((uint32_t)packet[43] << 16) + ((uint32_t)packet[44] << 8) + packet[45]);
+    data[0] = (((uint32_t)packet[34] << 24) | ((uint32_t)packet[35] << 16) | ((uint32_t)packet[36] << 8) | packet[37]);
+    data[1] = (((uint32_t)packet[38] << 24) | ((uint32_t)packet[39] << 16) | ((uint32_t)packet[40] << 8) | packet[41]);
+    data[2] = (((uint32_t)packet[42] << 24) | ((uint32_t)packet[43] << 16) | ((uint32_t)packet[44] << 8) | packet[45]);
     return 0;
 }
 uint8_t MPU6050::dmpGetAccel(int16_t *data, const uint8_t* packet) {
     // TODO: accommodate different arrangements of sent data (ONLY default supported now)
     if (packet == 0) packet = dmpPacketBuffer;
-    data[0] = (packet[34] << 8) + packet[35];
-    data[1] = (packet[38] << 8) + packet[39];
-    data[2] = (packet[42] << 8) + packet[43];
+    data[0] = (packet[34] << 8) | packet[35];
+    data[1] = (packet[38] << 8) | packet[39];
+    data[2] = (packet[42] << 8) | packet[43];
     return 0;
 }
 uint8_t MPU6050::dmpGetAccel(VectorInt16 *v, const uint8_t* packet) {
     // TODO: accommodate different arrangements of sent data (ONLY default supported now)
     if (packet == 0) packet = dmpPacketBuffer;
-    v -> x = (packet[34] << 8) + packet[35];
-    v -> y = (packet[38] << 8) + packet[39];
-    v -> z = (packet[42] << 8) + packet[43];
+    v -> x = (packet[34] << 8) | packet[35];
+    v -> y = (packet[38] << 8) | packet[39];
+    v -> z = (packet[42] << 8) | packet[43];
     return 0;
 }
 uint8_t MPU6050::dmpGetQuaternion(int32_t *data, const uint8_t* packet) {
     // TODO: accommodate different arrangements of sent data (ONLY default supported now)
     if (packet == 0) packet = dmpPacketBuffer;
-    data[0] = (((uint32_t)packet[0] << 24) + ((uint32_t)packet[1] << 16) + ((uint32_t)packet[2] << 8) + packet[3]);
-    data[1] = (((uint32_t)packet[4] << 24) + ((uint32_t)packet[5] << 16) + ((uint32_t)packet[6] << 8) + packet[7]);
-    data[2] = (((uint32_t)packet[8] << 24) + ((uint32_t)packet[9] << 16) + ((uint32_t)packet[10] << 8) + packet[11]);
-    data[3] = (((uint32_t)packet[12] << 24) + ((uint32_t)packet[13] << 16) + ((uint32_t)packet[14] << 8) + packet[15]);
+    data[0] = (((uint32_t)packet[0] << 24) | ((uint32_t)packet[1] << 16) | ((uint32_t)packet[2] << 8) | packet[3]);
+    data[1] = (((uint32_t)packet[4] << 24) | ((uint32_t)packet[5] << 16) | ((uint32_t)packet[6] << 8) | packet[7]);
+    data[2] = (((uint32_t)packet[8] << 24) | ((uint32_t)packet[9] << 16) | ((uint32_t)packet[10] << 8) | packet[11]);
+    data[3] = (((uint32_t)packet[12] << 24) | ((uint32_t)packet[13] << 16) | ((uint32_t)packet[14] << 8) | packet[15]);
     return 0;
 }
 uint8_t MPU6050::dmpGetQuaternion(int16_t *data, const uint8_t* packet) {
     // TODO: accommodate different arrangements of sent data (ONLY default supported now)
     if (packet == 0) packet = dmpPacketBuffer;
-    data[0] = ((packet[0] << 8) + packet[1]);
-    data[1] = ((packet[4] << 8) + packet[5]);
-    data[2] = ((packet[8] << 8) + packet[9]);
-    data[3] = ((packet[12] << 8) + packet[13]);
+    data[0] = ((packet[0] << 8) | packet[1]);
+    data[1] = ((packet[4] << 8) | packet[5]);
+    data[2] = ((packet[8] << 8) | packet[9]);
+    data[3] = ((packet[12] << 8) | packet[13]);
     return 0;
 }
 uint8_t MPU6050::dmpGetQuaternion(Quaternion *q, const uint8_t* packet) {
@@ -737,25 +737,25 @@ uint8_t MPU6050::dmpGetQuaternion(Quaternion *q, const uint8_t* packet) {
 uint8_t MPU6050::dmpGetGyro(int32_t *data, const uint8_t* packet) {
     // TODO: accommodate different arrangements of sent data (ONLY default supported now)
     if (packet == 0) packet = dmpPacketBuffer;
-    data[0] = (((uint32_t)packet[16] << 24) + ((uint32_t)packet[17] << 16) + ((uint32_t)packet[18] << 8) + packet[19]);
-    data[1] = (((uint32_t)packet[20] << 24) + ((uint32_t)packet[21] << 16) + ((uint32_t)packet[22] << 8) + packet[23]);
-    data[2] = (((uint32_t)packet[24] << 24) + ((uint32_t)packet[25] << 16) + ((uint32_t)packet[26] << 8) + packet[27]);
+    data[0] = (((uint32_t)packet[16] << 24) | ((uint32_t)packet[17] << 16) | ((uint32_t)packet[18] << 8) | packet[19]);
+    data[1] = (((uint32_t)packet[20] << 24) | ((uint32_t)packet[21] << 16) | ((uint32_t)packet[22] << 8) | packet[23]);
+    data[2] = (((uint32_t)packet[24] << 24) | ((uint32_t)packet[25] << 16) | ((uint32_t)packet[26] << 8) | packet[27]);
     return 0;
 }
 uint8_t MPU6050::dmpGetGyro(int16_t *data, const uint8_t* packet) {
     // TODO: accommodate different arrangements of sent data (ONLY default supported now)
     if (packet == 0) packet = dmpPacketBuffer;
-    data[0] = (packet[16] << 8) + packet[17];
-    data[1] = (packet[20] << 8) + packet[21];
-    data[2] = (packet[24] << 8) + packet[25];
+    data[0] = (packet[16] << 8) | packet[17];
+    data[1] = (packet[20] << 8) | packet[21];
+    data[2] = (packet[24] << 8) | packet[25];
     return 0;
 }
 uint8_t MPU6050::dmpGetMag(int16_t *data, const uint8_t* packet) {
     // TODO: accommodate different arrangements of sent data (ONLY default supported now)
     if (packet == 0) packet = dmpPacketBuffer;
-    data[0] = (packet[28] << 8) + packet[29];
-    data[1] = (packet[30] << 8) + packet[31];
-    data[2] = (packet[32] << 8) + packet[33];
+    data[0] = (packet[28] << 8) | packet[29];
+    data[1] = (packet[30] << 8) | packet[31];
+    data[2] = (packet[32] << 8) | packet[33];
     return 0;
 }
 // uint8_t MPU6050::dmpSetLinearAccelFilterCoefficient(float coef);


### PR DESCRIPTION
The (int32_t *data) variants of MPU6050::dmpGetAccel, MPU6050::dmpGetQuaternion and MPU6050::dmpGetGyro will only return the low bits 0-15! The shift left 24 and 16 of packet[x] will always result to 0, cause AVR/Arduino uses a 16bit integer. With the cast to uint32_t, we get also the bits 16-31into the data[] fields.

This fixes also the warnings:
/home/.../MPU6050/MPU6050_6Axis_MotionApps20.h:580:31: warning: left shift count >= width of type
     data[0] = ((packet[28] << 24) + (packet[29] << 16) + (packet[30] << 8) + packet[31]);