### PR TITLE
Do not read 0 bytes from the MPU-6050 FIFO_DATA register

### DIFF
--- a/Arduino/MPU6050/MPU6050.cpp
+++ b/Arduino/MPU6050/MPU6050.cpp
@@ -2741,7 +2741,11 @@ uint8_t MPU6050::getFIFOByte() {
     return buffer[0];
 }
 void MPU6050::getFIFOBytes(uint8_t *data, uint8_t length) {
-    I2Cdev::readBytes(devAddr, MPU6050_RA_FIFO_R_W, length, data);
+    if(length > 0){
+        I2Cdev::readBytes(devAddr, MPU6050_RA_FIFO_R_W, length, data);
+    } else {
+    	*data = 0;
+    }
 }
 /** Write byte to FIFO buffer.
  * @see getFIFOByte()


### PR DESCRIPTION
Do not attempt to read data from MPU-6050 FIFO if the requested data length is 0.

In the MPU-6050 Register Map document (RS-MPU-6000A-00v4.2.pdf) section 4.31, it states that: "The user should check FIFO_COUNT to ensure that the FIFO buffer is not read when empty."

For me, this changes fixes issue #164: MPU6050 dmpInitialize hangs in Fastwire mode