### PR TITLE
MPU6050/MPU9150 - ARM is not the only non-AVR type of CPU

### DIFF
--- a/Arduino/MPU6050/MPU6050.h
+++ b/Arduino/MPU6050/MPU6050.h
@@ -42,7 +42,7 @@ THE SOFTWARE.
 // supporting link:  http://forum.arduino.cc/index.php?&topic=143444.msg1079517#msg1079517
 // also: http://forum.arduino.cc/index.php?&topic=141571.msg1062899#msg1062899s
 
-#ifndef __arm__
+#ifdef __AVR__
 #include <avr/pgmspace.h>
 #else
 //#define PROGMEM /* empty */

--- a/Arduino/MPU6050/MPU6050_6Axis_MotionApps20.h
+++ b/Arduino/MPU6050/MPU6050_6Axis_MotionApps20.h
@@ -43,7 +43,7 @@ THE SOFTWARE.
 
 // Tom Carpenter's conditional PROGMEM code
 // http://forum.arduino.cc/index.php?topic=129407.0
-#ifndef __arm__
+#ifdef __AVR__
     #include <avr/pgmspace.h>
 #else
     // Teensy 3.0 library conditional PROGMEM code from Paul Stoffregen

--- a/Arduino/MPU6050/MPU6050_9Axis_MotionApps41.h
+++ b/Arduino/MPU6050/MPU6050_9Axis_MotionApps41.h
@@ -43,7 +43,7 @@ THE SOFTWARE.
 
 // Tom Carpenter's conditional PROGMEM code
 // http://forum.arduino.cc/index.php?topic=129407.0
-#ifndef __arm__
+#ifdef __AVR__
     #include <avr/pgmspace.h>
 #else
     // Teensy 3.0 library conditional PROGMEM code from Paul Stoffregen

--- a/Arduino/MPU9150/MPU9150.h
+++ b/Arduino/MPU9150/MPU9150.h
@@ -41,7 +41,7 @@ THE SOFTWARE.
 
 // supporting link:  http://forum.arduino.cc/index.php?&topic=143444.msg1079517#msg1079517
 // also: http://forum.arduino.cc/index.php?&topic=141571.msg1062899#msg1062899s
-#ifndef __arm__
+#ifdef __AVR__
 #include <avr/pgmspace.h>
 #else
 #define PROGMEM /* empty */

--- a/Arduino/MPU9150/MPU9150_9Axis_MotionApps41.h
+++ b/Arduino/MPU9150/MPU9150_9Axis_MotionApps41.h
@@ -43,7 +43,7 @@ THE SOFTWARE.
 
 // Tom Carpenter's conditional PROGMEM code
 // http://forum.arduino.cc/index.php?topic=129407.0
-#ifndef __arm__
+#ifdef __AVR__
     #include <avr/pgmspace.h>
 #else
     // Teensy 3.0 library conditional PROGMEM code from Paul Stoffregen


### PR DESCRIPTION
The conditional PROGMEM code should only be enabled on AVR boards, therefore it makes more sense to check for __AVR__ than __arm__.

This fixes the code for use on other CPUs -- In my case, an ESP8266