### PR TITLE
Updates to fix spark/particle support

### DIFF
--- a/Arduino/I2Cdev/I2Cdev.h
+++ b/Arduino/I2Cdev/I2Cdev.h
@@ -91,8 +91,9 @@ THE SOFTWARE.
 #endif
 
 #ifdef SPARK
-    #include <spark_wiring_i2c.h>
+    #include "application.h"
     #define ARDUINO 101
+    #define BUFFER_LENGTH 32
 #endif
 
 


### PR DESCRIPTION
- Updated to use the recommended (long term supported) spark/particle detection code
- Set the BUFFER_LENGTH define to match the one from arduino (not a global define in particle-land)

Both changes are tested and backward-compatible.
