### PR TITLE
Add support for AK8963 magnetometer

### DIFF
--- a/Arduino/AK8963/AK8963.cpp
+++ b/Arduino/AK8963/AK8963.cpp
@@ -145,8 +145,10 @@ uint8_t AK8963::getResolution() {
 void AK8963::setResolution(uint8_t res) {
     I2Cdev::writeBit(devAddr, AK8963_RA_CNTL1, AK8963_CNTL1_RES_BIT, res);
 }
+
+// CNTL2 register
 void AK8963::reset() {
-    I2Cdev::writeBits(devAddr, AK8963_RA_CNTL1, AK8963_CNTL1_MODE_BIT, AK8963_CNTL1_MODE_LENGTH, AK8963_MODE_POWERDOWN);
+    I2Cdev::writeByte(devAddr, AK8963_RA_CNTL2, AK8963_CNTL2_RESET);
 }
 
 // ASTC register

--- a/Arduino/AK8963/AK8963.cpp
+++ b/Arduino/AK8963/AK8963.cpp
@@ -1,0 +1,195 @@
+// I2Cdev library collection - AK8963 I2C device class header file
+// Based on AKM AK8963 datasheet, 10/2013
+// 8/27/2011 by Jeff Rowberg <jeff@rowberg.net>
+// Updates should (hopefully) always be available at https://github.com/jrowberg/i2cdevlib
+//
+// Changelog:
+//     2016-01-02 - initial release based on AK8975 code
+//
+
+/* ============================================
+I2Cdev device library code is placed under the MIT license
+Copyright (c) 2011 Jeff Rowberg
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+===============================================
+*/
+
+#include "AK8963.h"
+
+/** Default constructor, uses default I2C address.
+ * @see AK8963_DEFAULT_ADDRESS
+ */
+AK8963::AK8963() {
+    devAddr = AK8963_DEFAULT_ADDRESS;
+}
+
+/** Specific address constructor.
+ * @param address I2C address
+ * @see AK8963_DEFAULT_ADDRESS
+ * @see AK8963_ADDRESS_00
+ */
+AK8963::AK8963(uint8_t address) {
+    devAddr = address;
+}
+
+/** Power on and prepare for general usage.
+ * No specific pre-configuration is necessary for this device.
+ */
+void AK8963::initialize() {
+}
+
+/** Verify the I2C connection.
+ * Make sure the device is connected and responds as expected.
+ * @return True if connection is valid, false otherwise
+ */
+bool AK8963::testConnection() {
+    if (I2Cdev::readByte(devAddr, AK8963_RA_WIA, buffer) == 1) {
+        return (buffer[0] == 0x48);
+    }
+    return false;
+}
+
+// WIA register
+
+uint8_t AK8963::getDeviceID() {
+    I2Cdev::readByte(devAddr, AK8963_RA_WIA, buffer);
+    return buffer[0];
+}
+
+// INFO register
+
+uint8_t AK8963::getInfo() {
+    I2Cdev::readByte(devAddr, AK8963_RA_INFO, buffer);
+    return buffer[0];
+}
+
+// ST1 register
+
+bool AK8963::getDataReady() {
+    I2Cdev::readBit(devAddr, AK8963_RA_ST1, AK8963_ST1_DRDY_BIT, buffer);
+    return buffer[0];
+}
+
+bool AK8963::getDataOverrun() {
+    I2Cdev::readBit(devAddr, AK8963_RA_ST1, AK8963_ST1_DOR_BIT, buffer);
+    return buffer[0];
+}
+
+// H* registers
+void AK8963::getHeading(int16_t *x, int16_t *y, int16_t *z) {
+    I2Cdev::writeByte(devAddr, AK8963_RA_CNTL1, AK8963_MODE_SINGLE);
+    delay(10);
+    I2Cdev::readBytes(devAddr, AK8963_RA_HXL, 6, buffer);
+    *x = (((int16_t)buffer[1]) << 8) | buffer[0];
+    *y = (((int16_t)buffer[3]) << 8) | buffer[2];
+    *z = (((int16_t)buffer[5]) << 8) | buffer[4];
+}
+int16_t AK8963::getHeadingX() {
+    I2Cdev::writeByte(devAddr, AK8963_RA_CNTL1, AK8963_MODE_SINGLE);
+    delay(10);
+    I2Cdev::readBytes(devAddr, AK8963_RA_HXL, 2, buffer);
+    return (((int16_t)buffer[1]) << 8) | buffer[0];
+}
+int16_t AK8963::getHeadingY() {
+    I2Cdev::writeByte(devAddr, AK8963_RA_CNTL1, AK8963_MODE_SINGLE);
+    delay(10);
+    I2Cdev::readBytes(devAddr, AK8963_RA_HYL, 2, buffer);
+    return (((int16_t)buffer[1]) << 8) | buffer[0];
+}
+int16_t AK8963::getHeadingZ() {
+    I2Cdev::writeByte(devAddr, AK8963_RA_CNTL1, AK8963_MODE_SINGLE);
+    delay(10);
+    I2Cdev::readBytes(devAddr, AK8963_RA_HZL, 2, buffer);
+    return (((int16_t)buffer[1]) << 8) | buffer[0];
+}
+
+// ST2 register
+bool AK8963::getOverflowStatus() {
+    I2Cdev::readBit(devAddr, AK8963_RA_ST2, AK8963_ST2_HOFL_BIT, buffer);
+    return buffer[0];
+}
+bool AK8963::getOutputBit() {
+    I2Cdev::readBit(devAddr, AK8963_RA_ST2, AK8963_ST2_BITM_BIT, buffer);
+    return buffer[0];
+}
+
+// CNTL1 register
+uint8_t AK8963::getMode() {
+    I2Cdev::readBits(devAddr, AK8963_RA_CNTL1, AK8963_CNTL1_MODE_BIT, AK8963_CNTL1_MODE_LENGTH, buffer);
+    return buffer[0];
+}
+void AK8963::setMode(uint8_t mode) {
+    I2Cdev::writeBits(devAddr, AK8963_RA_CNTL1, AK8963_CNTL1_MODE_BIT, AK8963_CNTL1_MODE_LENGTH, mode);
+}
+uint8_t AK8963::getResolution() {
+    I2Cdev::readBit(devAddr, AK8963_RA_CNTL1, AK8963_CNTL1_RES_BIT, buffer);
+    return buffer[0];
+}
+void AK8963::setResolution(uint8_t res) {
+    I2Cdev::writeBit(devAddr, AK8963_RA_CNTL1, AK8963_CNTL1_RES_BIT, res);
+}
+void AK8963::reset() {
+    I2Cdev::writeBits(devAddr, AK8963_RA_CNTL1, AK8963_CNTL1_MODE_BIT, AK8963_CNTL1_MODE_LENGTH, AK8963_MODE_POWERDOWN);
+}
+
+// ASTC register
+void AK8963::setSelfTest(bool enabled) {
+    I2Cdev::writeBit(devAddr, AK8963_RA_ASTC, AK8963_ASTC_SELF_BIT, enabled);
+}
+
+// I2CDIS
+void AK8963::disableI2C() {
+    I2Cdev::writeByte(devAddr, AK8963_RA_I2CDIS, AK8963_I2CDIS_DISABLE);
+}
+
+// ASA* registers
+void AK8963::getAdjustment(int8_t *x, int8_t *y, int8_t *z) {
+    I2Cdev::readBytes(devAddr, AK8963_RA_ASAX, 3, buffer);
+    *x = buffer[0];
+    *y = buffer[1];
+    *z = buffer[2];
+}
+void AK8963::setAdjustment(int8_t x, int8_t y, int8_t z) {
+    buffer[0] = x;
+    buffer[1] = y;
+    buffer[2] = z;
+    I2Cdev::writeBytes(devAddr, AK8963_RA_ASAX, 3, buffer);
+}
+uint8_t AK8963::getAdjustmentX() {
+    I2Cdev::readByte(devAddr, AK8963_RA_ASAX, buffer);
+    return buffer[0];
+}
+void AK8963::setAdjustmentX(uint8_t x) {
+    I2Cdev::writeByte(devAddr, AK8963_RA_ASAX, x);
+}
+uint8_t AK8963::getAdjustmentY() {
+    I2Cdev::readByte(devAddr, AK8963_RA_ASAY, buffer);
+    return buffer[0];
+}
+void AK8963::setAdjustmentY(uint8_t y) {
+    I2Cdev::writeByte(devAddr, AK8963_RA_ASAY, y);
+}
+uint8_t AK8963::getAdjustmentZ() {
+    I2Cdev::readByte(devAddr, AK8963_RA_ASAZ, buffer);
+    return buffer[0];
+}
+void AK8963::setAdjustmentZ(uint8_t z) {
+    I2Cdev::writeByte(devAddr, AK8963_RA_ASAZ, z);
+}

--- a/Arduino/AK8963/AK8963.cpp
+++ b/Arduino/AK8963/AK8963.cpp
@@ -94,28 +94,20 @@ bool AK8963::getDataOverrun() {
 
 // H* registers
 void AK8963::getHeading(int16_t *x, int16_t *y, int16_t *z) {
-    I2Cdev::writeByte(devAddr, AK8963_RA_CNTL1, AK8963_MODE_SINGLE);
-    delay(10);
     I2Cdev::readBytes(devAddr, AK8963_RA_HXL, 6, buffer);
     *x = (((int16_t)buffer[1]) << 8) | buffer[0];
     *y = (((int16_t)buffer[3]) << 8) | buffer[2];
     *z = (((int16_t)buffer[5]) << 8) | buffer[4];
 }
 int16_t AK8963::getHeadingX() {
-    I2Cdev::writeByte(devAddr, AK8963_RA_CNTL1, AK8963_MODE_SINGLE);
-    delay(10);
     I2Cdev::readBytes(devAddr, AK8963_RA_HXL, 2, buffer);
     return (((int16_t)buffer[1]) << 8) | buffer[0];
 }
 int16_t AK8963::getHeadingY() {
-    I2Cdev::writeByte(devAddr, AK8963_RA_CNTL1, AK8963_MODE_SINGLE);
-    delay(10);
     I2Cdev::readBytes(devAddr, AK8963_RA_HYL, 2, buffer);
     return (((int16_t)buffer[1]) << 8) | buffer[0];
 }
 int16_t AK8963::getHeadingZ() {
-    I2Cdev::writeByte(devAddr, AK8963_RA_CNTL1, AK8963_MODE_SINGLE);
-    delay(10);
     I2Cdev::readBytes(devAddr, AK8963_RA_HZL, 2, buffer);
     return (((int16_t)buffer[1]) << 8) | buffer[0];
 }

--- a/Arduino/AK8963/AK8963.h
+++ b/Arduino/AK8963/AK8963.h
@@ -72,6 +72,8 @@ THE SOFTWARE.
 #define AK8963_CNTL1_RES_BIT            4
 #define AK8963_CNTL1_MODE_LENGTH        4
 
+#define AK8963_CNTL2_RESET              0x01
+
 #define AK8963_MODE_POWERDOWN           0x0
 #define AK8963_MODE_SINGLE              0x1
 #define AK8963_MODE_CONTINUOUS_8HZ      0x2

--- a/Arduino/AK8963/AK8963.h
+++ b/Arduino/AK8963/AK8963.h
@@ -1,0 +1,146 @@
+// I2Cdev library collection - AK8963 I2C device class header file
+// Based on AKM AK8963 datasheet, 10/2013
+// 8/27/2011 by Jeff Rowberg <jeff@rowberg.net>
+// Updates should (hopefully) always be available at https://github.com/jrowberg/i2cdevlib
+//
+// Changelog:
+//     2016-01-02 - initial release based on AK8975 code
+//
+
+/* ============================================
+I2Cdev device library code is placed under the MIT license
+Copyright (c) 2011 Jeff Rowberg
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+===============================================
+*/
+
+#ifndef _AK8963_H_
+#define _AK8963_H_
+
+#include "I2Cdev.h"
+
+#define AK8963_ADDRESS_00         0x0C
+#define AK8963_ADDRESS_01         0x0D
+#define AK8963_ADDRESS_10         0x0E
+#define AK8963_ADDRESS_11         0x0F
+#define AK8963_DEFAULT_ADDRESS    AK8963_ADDRESS_00
+
+#define AK8963_RA_WIA             0x00
+#define AK8963_RA_INFO            0x01
+#define AK8963_RA_ST1             0x02
+#define AK8963_RA_HXL             0x03
+#define AK8963_RA_HXH             0x04
+#define AK8963_RA_HYL             0x05
+#define AK8963_RA_HYH             0x06
+#define AK8963_RA_HZL             0x07
+#define AK8963_RA_HZH             0x08
+#define AK8963_RA_ST2             0x09
+#define AK8963_RA_CNTL1           0x0A
+#define AK8963_RA_CNTL2           0x0B
+#define AK8963_RA_ASTC            0x0C
+#define AK8963_RA_TS1             0x0D // SHIPMENT TEST, DO NOT USE
+#define AK8963_RA_TS2             0x0E // SHIPMENT TEST, DO NOT USE
+#define AK8963_RA_I2CDIS          0x0F
+#define AK8963_RA_ASAX            0x10
+#define AK8963_RA_ASAY            0x11
+#define AK8963_RA_ASAZ            0x12
+
+#define AK8963_ST1_DRDY_BIT       0
+#define AK8963_ST1_DOR_BIT        1
+
+#define AK8963_ST2_HOFL_BIT       3
+#define AK8963_ST2_BITM_BIT       4
+
+#define AK8963_CNTL1_MODE_BIT     3
+#define AK8963_CNTL1_RES_BIT      4
+#define AK8963_CNTL1_MODE_LENGTH  4
+
+#define AK8963_MODE_POWERDOWN     0x0
+#define AK8963_MODE_SINGLE        0x1
+#define AK8963_MODE_SELFTEST      0x8
+#define AK8963_MODE_FUSEROM       0xF
+
+#define AK8963_RES_14_BIT         0
+#define AK8963_RES_16_BIT         1
+
+#define AK8963_CNTL2_SRST_BIT     0
+
+#define AK8963_ASTC_SELF_BIT      6
+
+#define AK8963_I2CDIS_DISABLE     0x1B
+
+class AK8963 {
+    public:
+        AK8963();
+        AK8963(uint8_t address);
+
+        void initialize();
+        bool testConnection();
+
+        // WIA register
+        uint8_t getDeviceID();
+
+        // INFO register
+        uint8_t getInfo();
+
+        // ST1 register
+        bool getDataReady();
+        bool getDataOverrun();
+
+        // H* registers
+        void getHeading(int16_t *x, int16_t *y, int16_t *z);
+        int16_t getHeadingX();
+        int16_t getHeadingY();
+        int16_t getHeadingZ();
+
+        // ST2 register
+        bool getOverflowStatus();
+        bool getOutputBit();
+
+        // CNTL1 register
+        uint8_t getMode();
+        void setMode(uint8_t mode);
+        uint8_t getResolution();
+        void setResolution(uint8_t resolution);
+        void reset();
+
+        // ASTC register
+        void setSelfTest(bool enabled);
+
+        // I2CDIS
+        void disableI2C(); // um, why...?
+
+        // ASA* registers
+        void getAdjustment(int8_t *x, int8_t *y, int8_t *z);
+        void setAdjustment(int8_t x, int8_t y, int8_t z);
+        uint8_t getAdjustmentX();
+        void setAdjustmentX(uint8_t x);
+        uint8_t getAdjustmentY();
+        void setAdjustmentY(uint8_t y);
+        uint8_t getAdjustmentZ();
+        void setAdjustmentZ(uint8_t z);
+
+    private:
+        uint8_t devAddr;
+        uint8_t buffer[6];
+        uint8_t mode;
+};
+
+#endif /* _AK8963_H_ */

--- a/Arduino/AK8963/AK8963.h
+++ b/Arduino/AK8963/AK8963.h
@@ -36,55 +36,58 @@ THE SOFTWARE.
 
 #include "I2Cdev.h"
 
-#define AK8963_ADDRESS_00         0x0C
-#define AK8963_ADDRESS_01         0x0D
-#define AK8963_ADDRESS_10         0x0E
-#define AK8963_ADDRESS_11         0x0F
-#define AK8963_DEFAULT_ADDRESS    AK8963_ADDRESS_00
+#define AK8963_ADDRESS_00               0x0C
+#define AK8963_ADDRESS_01               0x0D
+#define AK8963_ADDRESS_10               0x0E
+#define AK8963_ADDRESS_11               0x0F
+#define AK8963_DEFAULT_ADDRESS          AK8963_ADDRESS_00
 
-#define AK8963_RA_WIA             0x00
-#define AK8963_RA_INFO            0x01
-#define AK8963_RA_ST1             0x02
-#define AK8963_RA_HXL             0x03
-#define AK8963_RA_HXH             0x04
-#define AK8963_RA_HYL             0x05
-#define AK8963_RA_HYH             0x06
-#define AK8963_RA_HZL             0x07
-#define AK8963_RA_HZH             0x08
-#define AK8963_RA_ST2             0x09
-#define AK8963_RA_CNTL1           0x0A
-#define AK8963_RA_CNTL2           0x0B
-#define AK8963_RA_ASTC            0x0C
-#define AK8963_RA_TS1             0x0D // SHIPMENT TEST, DO NOT USE
-#define AK8963_RA_TS2             0x0E // SHIPMENT TEST, DO NOT USE
-#define AK8963_RA_I2CDIS          0x0F
-#define AK8963_RA_ASAX            0x10
-#define AK8963_RA_ASAY            0x11
-#define AK8963_RA_ASAZ            0x12
+#define AK8963_RA_WIA                   0x00
+#define AK8963_RA_INFO                  0x01
+#define AK8963_RA_ST1                   0x02
+#define AK8963_RA_HXL                   0x03
+#define AK8963_RA_HXH                   0x04
+#define AK8963_RA_HYL                   0x05
+#define AK8963_RA_HYH                   0x06
+#define AK8963_RA_HZL                   0x07
+#define AK8963_RA_HZH                   0x08
+#define AK8963_RA_ST2                   0x09
+#define AK8963_RA_CNTL1                 0x0A
+#define AK8963_RA_CNTL2                 0x0B
+#define AK8963_RA_ASTC                  0x0C
+#define AK8963_RA_TS1                   0x0D // SHIPMENT TEST, DO NOT USE
+#define AK8963_RA_TS2                   0x0E // SHIPMENT TEST, DO NOT USE
+#define AK8963_RA_I2CDIS                0x0F
+#define AK8963_RA_ASAX                  0x10
+#define AK8963_RA_ASAY                  0x11
+#define AK8963_RA_ASAZ                  0x12
 
-#define AK8963_ST1_DRDY_BIT       0
-#define AK8963_ST1_DOR_BIT        1
+#define AK8963_ST1_DRDY_BIT             0
+#define AK8963_ST1_DOR_BIT              1
 
-#define AK8963_ST2_HOFL_BIT       3
-#define AK8963_ST2_BITM_BIT       4
+#define AK8963_ST2_HOFL_BIT             3
+#define AK8963_ST2_BITM_BIT             4
 
-#define AK8963_CNTL1_MODE_BIT     3
-#define AK8963_CNTL1_RES_BIT      4
-#define AK8963_CNTL1_MODE_LENGTH  4
+#define AK8963_CNTL1_MODE_BIT           3
+#define AK8963_CNTL1_RES_BIT            4
+#define AK8963_CNTL1_MODE_LENGTH        4
 
-#define AK8963_MODE_POWERDOWN     0x0
-#define AK8963_MODE_SINGLE        0x1
-#define AK8963_MODE_SELFTEST      0x8
-#define AK8963_MODE_FUSEROM       0xF
+#define AK8963_MODE_POWERDOWN           0x0
+#define AK8963_MODE_SINGLE              0x1
+#define AK8963_MODE_CONTINUOUS_8HZ      0x2
+#define AK8963_MODE_EXTERNAL            0x4
+#define AK8963_MODE_CONTINUOUS_100HZ    0x6
+#define AK8963_MODE_SELFTEST            0x8
+#define AK8963_MODE_FUSEROM             0xF
 
-#define AK8963_RES_14_BIT         0
-#define AK8963_RES_16_BIT         1
+#define AK8963_RES_14_BIT               0
+#define AK8963_RES_16_BIT               1
 
-#define AK8963_CNTL2_SRST_BIT     0
+#define AK8963_CNTL2_SRST_BIT           0
 
-#define AK8963_ASTC_SELF_BIT      6
+#define AK8963_ASTC_SELF_BIT            6
 
-#define AK8963_I2CDIS_DISABLE     0x1B
+#define AK8963_I2CDIS_DISABLE           0x1B
 
 class AK8963 {
     public:

--- a/Arduino/AK8963/AK8963.h
+++ b/Arduino/AK8963/AK8963.h
@@ -69,8 +69,8 @@ THE SOFTWARE.
 #define AK8963_ST2_BITM_BIT             4
 
 #define AK8963_CNTL1_MODE_BIT           3
-#define AK8963_CNTL1_RES_BIT            4
 #define AK8963_CNTL1_MODE_LENGTH        4
+#define AK8963_CNTL1_RES_BIT            4
 
 #define AK8963_CNTL2_RESET              0x01
 

--- a/Arduino/AK8963/library.json
+++ b/Arduino/AK8963/library.json
@@ -1,0 +1,20 @@
+{
+  "name": "I2Cdevlib-AK8963",
+  "keywords": "compass, sensor, i2cdevlib, i2c",
+  "description": "AK8963 is 3-axis electronic compass IC with high sensitive Hall sensor technology",
+  "include": "Arduino/AK8963",
+  "repository":
+  {
+    "type": "git",
+    "url": "https://github.com/jrowberg/i2cdevlib.git"
+  },
+  "dependencies":
+  [
+    {
+      "name": "I2Cdevlib-Core",
+      "frameworks": "arduino"
+    }
+  ],
+  "frameworks": "arduino",
+  "platforms": "atmelavr"
+}


### PR DESCRIPTION
This PR adds support for the AK8963 magnetometer, based on the similar AK8975 magnetometer which is already supported by i2cdevlib.

Although the AK8963 and AK8975 have the same i2c address, there are various feature, resolution and feature differences. One of the main differences, apart from the increased sensitivity, is the ability to enable "continuous read" mode to get continuous magnetic field readings.

This has been tested on both the Arduino Nano and the Particle Photon.