### PR TITLE
Include math.h in BMP085 header since this device uses pow()

### DIFF
--- a/Arduino/BMP085/BMP085.h
+++ b/Arduino/BMP085/BMP085.h
@@ -34,6 +34,7 @@ THE SOFTWARE.
 #define _BMP085_H_
 
 #include "I2Cdev.h"
+#include <math.h>
 
 #define BMP085_ADDRESS              0x77
 #define BMP085_DEFAULT_ADDRESS      BMP085_ADDRESS
@@ -75,7 +76,7 @@ class BMP085 {
     public:
         BMP085();
         BMP085(uint8_t address);
-        
+
         void initialize();
         bool testConnection();
 


### PR DESCRIPTION
The BMP085 implementation uses `pow()` from `math.h`. This PR adds the math.h include to the BMP085 header (following convention) so that developers don't need to remember to do this in their own application.