### PR TITLE
Fixes for Arduino ADS1115

### DIFF
--- a/Arduino/ADS1115/ADS1115.cpp
+++ b/Arduino/ADS1115/ADS1115.cpp
@@ -307,9 +307,9 @@ float ADS1115::getMvPerCount() {
  */
 bool ADS1115::isConversionReady() {
     I2Cdev::readBitW(devAddr, ADS1115_RA_CONFIG, ADS1115_CFG_OS_BIT, buffer);
-    return !!buffer[0];
+    return buffer[0];
 }
-/** Set operational status.
+/** Trigger a new conversion.
  * Writing to this bit will only have effect while in power-down mode (no conversions active).
  * @see ADS1115_RA_CONFIG
  * @see ADS1115_CFG_OS_BIT
@@ -400,9 +400,9 @@ void ADS1115::setGain(uint8_t gain) {
  * @see ADS1115_RA_CONFIG
  * @see ADS1115_CFG_MODE_BIT
  */
-uint8_t ADS1115::getMode() {
+bool ADS1115::getMode() {
     I2Cdev::readBitW(devAddr, ADS1115_RA_CONFIG, ADS1115_CFG_MODE_BIT, buffer);
-    devMode = (uint8_t)buffer[0];
+    devMode = buffer[0];
     return devMode;
 }
 /** Set device mode.
@@ -412,7 +412,7 @@ uint8_t ADS1115::getMode() {
  * @see ADS1115_RA_CONFIG
  * @see ADS1115_CFG_MODE_BIT
  */
-void ADS1115::setMode(uint8_t mode) {
+void ADS1115::setMode(bool mode) {
     if (I2Cdev::writeBitW(devAddr, ADS1115_RA_CONFIG, ADS1115_CFG_MODE_BIT, mode)) {
         devMode = mode;
     }
@@ -451,9 +451,9 @@ void ADS1115::setRate(uint8_t rate) {
  * @see ADS1115_RA_CONFIG
  * @see ADS1115_CFG_COMP_MODE_BIT
  */
-uint8_t ADS1115::getComparatorMode() {
+bool ADS1115::getComparatorMode() {
     I2Cdev::readBitW(devAddr, ADS1115_RA_CONFIG, ADS1115_CFG_COMP_MODE_BIT, buffer);
-    return (uint8_t)buffer[0];
+    return buffer[0];
 }
 /** Set comparator mode.
  * @param mode New comparator mode
@@ -462,7 +462,7 @@ uint8_t ADS1115::getComparatorMode() {
  * @see ADS1115_RA_CONFIG
  * @see ADS1115_CFG_COMP_MODE_BIT
  */
-void ADS1115::setComparatorMode(uint8_t mode) {
+void ADS1115::setComparatorMode(bool mode) {
     I2Cdev::writeBitW(devAddr, ADS1115_RA_CONFIG, ADS1115_CFG_COMP_MODE_BIT, mode);
 }
 /** Get comparator polarity setting.
@@ -472,9 +472,9 @@ void ADS1115::setComparatorMode(uint8_t mode) {
  * @see ADS1115_RA_CONFIG
  * @see ADS1115_CFG_COMP_POL_BIT
  */
-uint8_t ADS1115::getComparatorPolarity() {
+bool ADS1115::getComparatorPolarity() {
     I2Cdev::readBitW(devAddr, ADS1115_RA_CONFIG, ADS1115_CFG_COMP_POL_BIT, buffer);
-    return (uint8_t)buffer[0];
+    return buffer[0];
 }
 /** Set comparator polarity setting.
  * @param polarity New comparator polarity setting
@@ -483,7 +483,7 @@ uint8_t ADS1115::getComparatorPolarity() {
  * @see ADS1115_RA_CONFIG
  * @see ADS1115_CFG_COMP_POL_BIT
  */
-void ADS1115::setComparatorPolarity(uint8_t polarity) {
+void ADS1115::setComparatorPolarity(bool polarity) {
     I2Cdev::writeBitW(devAddr, ADS1115_RA_CONFIG, ADS1115_CFG_COMP_POL_BIT, polarity);
 }
 /** Get comparator latch enabled value.
@@ -645,6 +645,5 @@ void ADS1115::showConfigRegister() {
       Serial.println(getValueFromBits(configRegister, 
         ADS1115_CFG_COMP_QUE_BIT,ADS1115_CFG_COMP_QUE_LENGTH), BIN);
     #endif
-
 };
 

--- a/Arduino/ADS1115/ADS1115.cpp
+++ b/Arduino/ADS1115/ADS1115.cpp
@@ -310,7 +310,7 @@ bool ADS1115::isConversionReady() {
     return !!buffer[0];
 }
 /** Set operational status.
- * This bit can only be written while in power-down mode (no conversions active).
+ * Writing to this bit will only have effect while in power-down mode (no conversions active).
  * @see ADS1115_RA_CONFIG
  * @see ADS1115_CFG_OS_BIT
  */

--- a/Arduino/ADS1115/ADS1115.cpp
+++ b/Arduino/ADS1115/ADS1115.cpp
@@ -107,6 +107,8 @@ bool ADS1115::pollConversion(uint16_t max_retries) {
  * effortless, but it has enormous potential to save power by only running the
  * comparison circuitry when needed.
  *
+ * @param triggerAndPoll If true (and only in singleshot mode) the conversion trigger 
+ *        will be executed and the conversion results will be polled.
  * @return 16-bit signed differential value
  * @see getConversionP0N1();
  * @see getConversionPON3();
@@ -127,12 +129,10 @@ bool ADS1115::pollConversion(uint16_t max_retries) {
  * @see ADS1115_MUX_P2_NG
  * @see ADS1115_MUX_P3_NG
  */
-int16_t ADS1115::getConversion() {
-    if (devMode == ADS1115_MODE_SINGLESHOT) 
-    {  
-      setOpStatus(ADS1115_OS_ACTIVE);
-      ADS1115::waitBusy(I2CDEV_DEFAULT_READ_TIMEOUT);
-      
+int16_t ADS1115::getConversion(bool triggerAndPoll) {
+    if (triggerAndPoll && devMode == ADS1115_MODE_SINGLESHOT) {
+      triggerConversion();
+      pollConversion(I2CDEV_DEFAULT_READ_TIMEOUT);
     }
     I2Cdev::readWord(devAddr, ADS1115_RA_CONVERSION, buffer);
     return buffer[0];
@@ -234,29 +234,30 @@ int16_t ADS1115::getConversionP3GND() {
  * Read the current differential and return it multiplied
  * by the constant for the current gain.  mV is returned to
  * increase the precision of the voltage
- *
+ * @param triggerAndPoll If true (and only in singleshot mode) the conversion trigger 
+ *        will be executed and the conversion results will be polled.
  */
-float ADS1115::getMilliVolts() {
+float ADS1115::getMilliVolts(bool triggerAndPoll) {
   switch (pgaMode) { 
     case ADS1115_PGA_6P144:
-      return (getConversion() * ADS1115_MV_6P144);
+      return (getConversion(triggerAndPoll) * ADS1115_MV_6P144);
       break;    
     case ADS1115_PGA_4P096:
-      return (getConversion() * ADS1115_MV_4P096);
+      return (getConversion(triggerAndPoll) * ADS1115_MV_4P096);
       break;             
     case ADS1115_PGA_2P048:    
-      return (getConversion() * ADS1115_MV_2P048);
+      return (getConversion(triggerAndPoll) * ADS1115_MV_2P048);
       break;       
     case ADS1115_PGA_1P024:     
-      return (getConversion() * ADS1115_MV_1P024);
+      return (getConversion(triggerAndPoll) * ADS1115_MV_1P024);
       break;       
     case ADS1115_PGA_0P512:      
-      return (getConversion() * ADS1115_MV_0P512);
+      return (getConversion(triggerAndPoll) * ADS1115_MV_0P512);
       break;       
     case ADS1115_PGA_0P256:           
     case ADS1115_PGA_0P256B:          
     case ADS1115_PGA_0P256C:      
-      return (getConversion() * ADS1115_MV_0P256);
+      return (getConversion(triggerAndPoll) * ADS1115_MV_0P256);
       break;       
   }
 }

--- a/Arduino/ADS1115/ADS1115.cpp
+++ b/Arduino/ADS1115/ADS1115.cpp
@@ -298,24 +298,21 @@ float ADS1115::getMvPerCount() {
 // CONFIG register
 
 /** Get operational status.
- * @return Current operational status (0 for active conversion, 1 for inactive)
- * @see ADS1115_OS_ACTIVE
- * @see ADS1115_OS_INACTIVE
+ * @return Current operational status (false for active conversion, true for inactive)
  * @see ADS1115_RA_CONFIG
  * @see ADS1115_CFG_OS_BIT
  */
-uint8_t ADS1115::getOpStatus() {
+bool ADS1115::isConversionReady() {
     I2Cdev::readBitW(devAddr, ADS1115_RA_CONFIG, ADS1115_CFG_OS_BIT, buffer);
-    return (uint8_t)buffer[0];
+    return !!buffer[0];
 }
 /** Set operational status.
  * This bit can only be written while in power-down mode (no conversions active).
- * @param status New operational status (0 does nothing, 1 to trigger conversion)
  * @see ADS1115_RA_CONFIG
  * @see ADS1115_CFG_OS_BIT
  */
-void ADS1115::setOpStatus(uint8_t status) { 
-    I2Cdev::writeBitW(devAddr, ADS1115_RA_CONFIG, ADS1115_CFG_OS_BIT, status);
+void ADS1115::triggerConversion() {
+    I2Cdev::writeBitW(devAddr, ADS1115_RA_CONFIG, ADS1115_CFG_OS_BIT, 1);
 }
 /** Get multiplexer connection.
  * @return Current multiplexer connection setting

--- a/Arduino/ADS1115/ADS1115.cpp
+++ b/Arduino/ADS1115/ADS1115.cpp
@@ -79,15 +79,17 @@ bool ADS1115::testConnection() {
     return I2Cdev::readWord(devAddr, ADS1115_RA_CONVERSION, buffer) == 1;
 }
 
-/** Wait until the single-shot conversion is finished
+/** Poll the operational status bit until the conversion is finished
  * Retry at most 'max_retries' times
- * conversion is finished, then return;
- * @see ADS1115_OS_INACTIVE
+ * conversion is finished, then return true;
+ * @see ADS1115_CFG_OS_BIT
+ * @return True if data is available, false otherwise
  */
-void ADS1115::waitBusy(uint16_t max_retries) {  
+bool ADS1115::pollConversion(uint16_t max_retries) {  
   for(uint16_t i = 0; i < max_retries; i++) {
-    if (getOpStatus()==ADS1115_OS_INACTIVE) break;    
+    if (isConversionReady()) return true;
   }
+  return false;
 }
 
 /** Read differential value based on current MUX configuration.

--- a/Arduino/ADS1115/ADS1115.cpp
+++ b/Arduino/ADS1115/ADS1115.cpp
@@ -90,7 +90,6 @@ void ADS1115::waitBusy(uint16_t max_retries) {
   }
 }
 
-
 /** Read differential value based on current MUX configuration.
  * The default MUX setting sets the device to get the differential between the
  * AIN0 and AIN1 pins. There are 8 possible MUX settings, but if you are using
@@ -570,22 +569,19 @@ void ADS1115::setHighThreshold(int16_t threshold) {
 }
 
 // Create a mask between two bits
-unsigned createMask(unsigned a, unsigned b)
-{
+unsigned createMask(unsigned a, unsigned b) {
    unsigned mask = 0;
    for (unsigned i=a; i<=b; i++)
        mask |= 1 << i;
    return mask;
 }
 
-uint16_t shiftDown(uint16_t extractFrom, int places)
-{
+uint16_t shiftDown(uint16_t extractFrom, int places) {
   return (extractFrom >> places);
 }
 
 
-uint16_t getValueFromBits(uint16_t extractFrom, int high, int length) 
-{
+uint16_t getValueFromBits(uint16_t extractFrom, int high, int length) {
    int low= high-length +1;
    uint16_t mask = createMask(low ,high);
    return shiftDown(extractFrom & mask, low); 
@@ -593,8 +589,7 @@ uint16_t getValueFromBits(uint16_t extractFrom, int high, int length)
 
 /** Show all the config register settings
  */
-void ADS1115::showConfigRegister()
-{
+void ADS1115::showConfigRegister() {
     I2Cdev::readWord(devAddr, ADS1115_RA_CONFIG, buffer);
     uint16_t configRegister =buffer[0];    
     
@@ -638,6 +633,6 @@ void ADS1115::showConfigRegister()
       Serial.println(getValueFromBits(configRegister, 
         ADS1115_CFG_COMP_QUE_BIT,ADS1115_CFG_COMP_QUE_LENGTH), BIN);
     #endif
-    
+
 };
 

--- a/Arduino/ADS1115/ADS1115.cpp
+++ b/Arduino/ADS1115/ADS1115.cpp
@@ -567,6 +567,18 @@ void ADS1115::setHighThreshold(int16_t threshold) {
     I2Cdev::writeWord(devAddr, ADS1115_RA_HI_THRESH, threshold);
 }
 
+/** Configures ALERT/RDY pin as a conversion ready pin.
+ *  It does this by setting the MSB of the high threshold register to '1' and the MSB 
+ *  of the low threshold register to '0'. COMP_POL and COMP_QUE bits will be set to '0'.
+ *  Note: ALERT/RDY pin requires a pull up resistor.
+ */
+void ADS1115::setConversionReadyPinMode() {
+    I2Cdev::writeBitW(devAddr, ADS1115_RA_HI_THRESH, 15, 1);
+    I2Cdev::writeBitW(devAddr, ADS1115_RA_LO_THRESH, 15, 0);
+    setComparatorPolarity(0);
+    setComparatorQueueMode(0);
+}
+
 // Create a mask between two bits
 unsigned createMask(unsigned a, unsigned b) {
    unsigned mask = 0;

--- a/Arduino/ADS1115/ADS1115.h
+++ b/Arduino/ADS1115/ADS1115.h
@@ -135,22 +135,22 @@ class ADS1115 {
     public:
         ADS1115();
         ADS1115(uint8_t address);
-        
+
         void initialize();
         bool testConnection();
-        
+
         // SINGLE SHOT utilities
         void waitBusy(uint16_t max_retries);
 
         // Read the current CONVERSION register
         int16_t getConversion();
-        
+
         // Differential
         int16_t getConversionP0N1();
         int16_t getConversionP0N3();
         int16_t getConversionP1N3();
         int16_t getConversionP2N3();
-        
+
         // Single-ended
         int16_t getConversionP0GND();
         int16_t getConversionP1GND();
@@ -186,7 +186,7 @@ class ADS1115 {
         void setLowThreshold(int16_t threshold);
         int16_t getHighThreshold();
         void setHighThreshold(int16_t threshold);
-        
+
         // DEBUG
         void showConfigRegister();
 

--- a/Arduino/ADS1115/ADS1115.h
+++ b/Arduino/ADS1115/ADS1115.h
@@ -178,6 +178,7 @@ class ADS1115 {
         void setComparatorLatchEnabled(bool enabled);
         uint8_t getComparatorQueueMode();
         void setComparatorQueueMode(uint8_t mode);
+        void setConversionReadyPinMode();
 
         // *_THRESH registers
         int16_t getLowThreshold();

--- a/Arduino/ADS1115/ADS1115.h
+++ b/Arduino/ADS1115/ADS1115.h
@@ -166,14 +166,14 @@ class ADS1115 {
         void setMultiplexer(uint8_t mux);
         uint8_t getGain();
         void setGain(uint8_t gain);
-        uint8_t getMode();
-        void setMode(uint8_t mode);
+        bool getMode();
+        void setMode(bool mode);
         uint8_t getRate();
         void setRate(uint8_t rate);
-        uint8_t getComparatorMode();
-        void setComparatorMode(uint8_t mode);
-        uint8_t getComparatorPolarity();
-        void setComparatorPolarity(uint8_t polarity);
+        bool getComparatorMode();
+        void setComparatorMode(bool mode);
+        bool getComparatorPolarity();
+        void setComparatorPolarity(bool polarity);
         bool getComparatorLatchEnabled();
         void setComparatorLatchEnabled(bool enabled);
         uint8_t getComparatorQueueMode();
@@ -192,7 +192,7 @@ class ADS1115 {
     private:
         uint8_t devAddr;
         uint16_t buffer[2];
-        uint8_t devMode;
+        bool    devMode;
         uint8_t muxMode;
         uint8_t pgaMode;
 };

--- a/Arduino/ADS1115/ADS1115.h
+++ b/Arduino/ADS1115/ADS1115.h
@@ -142,7 +142,7 @@ class ADS1115 {
         void triggerConversion();
 
         // Read the current CONVERSION register
-        int16_t getConversion();
+        int16_t getConversion(bool triggerAndPoll=true);
 
         // Differential
         int16_t getConversionP0N1();
@@ -157,7 +157,7 @@ class ADS1115 {
         int16_t getConversionP3GND();
 
         // Utility
-        float getMilliVolts(); 
+        float getMilliVolts(bool triggerAndPoll=true);
         float getMvPerCount();
 
         // CONFIG register

--- a/Arduino/ADS1115/ADS1115.h
+++ b/Arduino/ADS1115/ADS1115.h
@@ -138,7 +138,7 @@ class ADS1115 {
         bool testConnection();
 
         // SINGLE SHOT utilities
-        void waitBusy(uint16_t max_retries);
+        bool pollConversion(uint16_t max_retries);
         void triggerConversion();
 
         // Read the current CONVERSION register

--- a/Arduino/ADS1115/ADS1115.h
+++ b/Arduino/ADS1115/ADS1115.h
@@ -69,8 +69,6 @@ THE SOFTWARE.
 #define ADS1115_CFG_COMP_QUE_BIT    1
 #define ADS1115_CFG_COMP_QUE_LENGTH 2
 
-#define ADS1115_OS_INACTIVE         0x00
-#define ADS1115_OS_ACTIVE           0x01
 
 #define ADS1115_MUX_P0_N1           0x00 // default
 #define ADS1115_MUX_P0_N3           0x01
@@ -141,6 +139,7 @@ class ADS1115 {
 
         // SINGLE SHOT utilities
         void waitBusy(uint16_t max_retries);
+        void triggerConversion();
 
         // Read the current CONVERSION register
         int16_t getConversion();
@@ -162,8 +161,7 @@ class ADS1115 {
         float getMvPerCount();
 
         // CONFIG register
-        uint8_t getOpStatus();
-        void setOpStatus(uint8_t op);
+        bool isConversionReady();
         uint8_t getMultiplexer();
         void setMultiplexer(uint8_t mux);
         uint8_t getGain();

--- a/Arduino/ADS1115/Examples/ADS1115_differential/ADS1115_differential.ino
+++ b/Arduino/ADS1115/Examples/ADS1115_differential/ADS1115_differential.ino
@@ -29,7 +29,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ===============================================
 */
-#include <Wire.h>
 #include "ADS1115.h"
 
 ADS1115 adc0(ADS1115_DEFAULT_ADDRESS); 
@@ -49,16 +48,14 @@ void setup() {
     
     // We're going to do continuous sampling
     adc0.setMode(ADS1115_MODE_CONTINUOUS);
-
 }
 
-void loop() 
-  {
+void loop() {
 
     // Sensor is on P0/N1 (pins 4/5)
     Serial.println("Sensor 1 ************************");
     // Set the gain (PGA) +/- 1.024v
-    adc0.setGain(ADS1115_PGA_1P024 );
+    adc0.setGain(ADS1115_PGA_1P024);
 
     // Get the number of counts of the accumulator
     Serial.print("Counts for sensor 1 is:");
@@ -69,7 +66,7 @@ void loop()
 
     // To turn the counts into a voltage, we can use
     Serial.print("Voltage for sensor 1 is:");
-    Serial.println(sensorOneCounts*adc0.getMvPerCount() );
+    Serial.println(sensorOneCounts*adc0.getMvPerCount());
     
     Serial.println();
      
@@ -90,9 +87,5 @@ void loop()
     Serial.println();
     
     delay(500);
-  }
-  
-
-  
-
+}
 

--- a/Arduino/ADS1115/Examples/ADS1115_single/ADS1115_single.ino
+++ b/Arduino/ADS1115/Examples/ADS1115_single/ADS1115_single.ino
@@ -1,0 +1,110 @@
+// I2C device class (I2Cdev) demonstration Arduino sketch for ADS1115 class
+// Example of reading two differential inputs of the ADS1115 and showing the value in mV
+// 2016-03-22 by Eadf (https://github.com/eadf)
+// Updates should (hopefully) always be available at https://github.com/jrowberg/i2cdevlib
+//
+// Changelog:
+//     2016-03-22 - initial release
+
+/* ============================================
+I2Cdev device library code is placed under the MIT license
+Copyright (c) 2011 Jeff Rowberg
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+===============================================
+*/
+
+#include "ADS1115.h"
+
+ADS1115 adc0(ADS1115_DEFAULT_ADDRESS);
+
+// Wire ADS1115 ALERT/RDY pin to Arduino pin 2
+const int alertReadyPin = 2;
+
+void setup() {    
+    //I2Cdev::begin();  // join I2C bus
+    Wire.begin();
+    Serial.begin(115200); // initialize serial communication 
+    
+    Serial.println("Testing device connections...");
+    Serial.println(adc0.testConnection() ? "ADS1115 connection successful" : "ADS1115 connection failed");
+    
+    adc0.initialize(); // initialize ADS1115 16 bit A/D chip
+
+    // We're going to do single shot sampling
+    adc0.setMode(ADS1115_MODE_SINGLESHOT);
+    
+    // Slow things down so that we can see that the "poll for conversion" code works
+    adc0.setRate(ADS1115_RATE_8);
+      
+    // Set the gain (PGA) +/- 6.144v
+    // Note that any analog input must be higher than –0.3V and less than VDD +0.3
+    adc0.setGain(ADS1115_PGA_6P144);
+    // ALERT/RDY pin will indicate when conversion is ready
+    
+    pinMode(alertReadyPin,INPUT_PULLUP);
+    adc0.setConversionReadyPinMode();
+
+    // To get output from this method, you'll need to turn on the 
+    //#define ADS1115_SERIAL_DEBUG // in the ADS1115.h file
+    #ifdef ADS1115_SERIAL_DEBUG
+    adc0.showConfigRegister();
+    Serial.print("HighThreshold="); Serial.println(adc0.getHighThreshold(),BIN);
+    Serial.print("LowThreshold="); Serial.println(adc0.getLowThreshold(),BIN);
+    #endif
+}
+
+/** Poll the assigned pin for conversion status 
+ */
+void pollAlertReadyPin() {
+  for (uint32_t i = 0; i<100000; i++)
+    if (!digitalRead(alertReadyPin)) return;
+   Serial.println("Failed to wait for AlertReadyPin, it's stuck high!");
+}
+
+void loop() {
+       
+    // The below method sets the mux and gets a reading.
+    adc0.setMultiplexer(ADS1115_MUX_P0_NG);
+    adc0.triggerConversion();
+    pollAlertReadyPin();
+    Serial.print("A0: "); Serial.print(adc0.getMilliVolts(false)); Serial.print("mV\t");
+    
+    adc0.setMultiplexer(ADS1115_MUX_P1_NG);
+    adc0.triggerConversion();
+    pollAlertReadyPin();
+    Serial.print("A1: "); Serial.print(adc0.getMilliVolts(false)); Serial.print("mV\t");
+    
+    adc0.setMultiplexer(ADS1115_MUX_P2_NG);
+    adc0.triggerConversion();
+    pollAlertReadyPin();
+    Serial.print("A2: "); Serial.print(adc0.getMilliVolts(false)); Serial.print("mV\t");
+    
+    adc0.setMultiplexer(ADS1115_MUX_P3_NG);
+    // Do conversion polling via I2C on this last reading: 
+    Serial.print("A3: "); Serial.print(adc0.getMilliVolts(true)); Serial.print("mV");
+    
+    Serial.println(digitalRead(alertReadyPin));
+    delay(500);
+}
+  
+
+  
+
+


### PR DESCRIPTION
## Bugfixes:
* `getMode()`was always returning ADS1115_MODE_CONTINUOUS
* `waitBusy()`never waited for conversion

## Modifications:
* All single bit get&set methods now uses`bool`instead of uint8_t, previously there were a mix of`uint8_t`and`bool`.
* Replaced`setOpStatus()`and`getOpStatus()`with the, hopefully, easier to use and understand `triggerConversion()`and`isConversionReady()`methods.
* `getConversion()`now takes a optional parameter. If`true`and in singleshot mode the method will trigger a new conversion. Previously it was always triggering a conversion and that was not so useful if you wanted to read the conversion the ALERT/RDY pin was signaling as ready.  The same parameter is, consequently,  in`getMilliVolts()`as well.
* Some indentation and formating so that the code looks like the rest of i2cdevlib

## Addons
* `setConversionReadyPinMode()`a mode where ADS1115 can trigger conversion status via a GPIO.
* Added a`ADS1115_MODE_SINGLESHOT`example.