### PR TITLE
Software I2C backend (Arduino)

### DIFF
--- a/Arduino/ADS1115/Examples/ADS1115_differential/ADS1115_differential.ino
+++ b/Arduino/ADS1115/Examples/ADS1115_differential/ADS1115_differential.ino
@@ -29,13 +29,12 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ===============================================
 */
-#include <Wire.h>
 #include "ADS1115.h"
 
 ADS1115 adc0(ADS1115_DEFAULT_ADDRESS); 
 
 void setup() {                
-    Wire.begin();  // join I2C bus
+    I2Cdev::begin();  // join I2C bus
     Serial.begin(19200); // initialize serial communication 
     Serial.println("Initializing I2C devices..."); 
     adc0.initialize(); // initialize ADS1115 16 bit A/D chip
@@ -52,8 +51,7 @@ void setup() {
 
 }
 
-void loop() 
-  {
+void loop() {
 
     // Sensor is on P0/N1 (pins 4/5)
     Serial.println("Sensor 1 ************************");

--- a/Arduino/ADXL345/Examples/ADXL345_raw/ADXL345_raw.ino
+++ b/Arduino/ADXL345/Examples/ADXL345_raw/ADXL345_raw.ino
@@ -29,9 +29,6 @@ THE SOFTWARE.
 ===============================================
 */
 
-// Arduino Wire library is required if I2Cdev I2CDEV_ARDUINO_WIRE implementation
-// is used in I2Cdev.h
-#include "Wire.h"
 
 // I2Cdev and ADXL345 must be installed as libraries, or else the .cpp/.h files
 // for both classes must be in the include path of your project
@@ -51,7 +48,7 @@ bool blinkState = false;
 
 void setup() {
     // join I2C bus (I2Cdev library doesn't do this automatically)
-    Wire.begin();
+    I2Cdev::begin();
 
     // initialize serial communication
     // (38400 chosen because it works as well at 8MHz as it does at 16MHz, but

--- a/Arduino/AK8975/Examples/AK8975_MPUEVB_heading/AK8975_MPUEVB_heading.ino
+++ b/Arduino/AK8975/Examples/AK8975_MPUEVB_heading/AK8975_MPUEVB_heading.ino
@@ -44,9 +44,6 @@ THE SOFTWARE.
 ===============================================
 */
 
-// Arduino Wire library is required if I2Cdev I2CDEV_ARDUINO_WIRE implementation
-// is used in I2Cdev.h
-#include "Wire.h"
 
 // I2Cdev, AK8975, and MPU6050 must be installed as libraries, or else the
 // .cpp/.h files for all classes must be in the include path of your project
@@ -71,7 +68,7 @@ bool blinkState = false;
 
 void setup() {
     // join I2C bus (I2Cdev library doesn't do this automatically)
-    Wire.begin();
+    I2Cdev::begin();
 
     // initialize serial communication
     // (38400 chosen because it works as well at 8MHz as it does at 16MHz, but

--- a/Arduino/AK8975/Examples/AK8975_MPUEVB_raw/AK8975_MPUEVB_raw.ino
+++ b/Arduino/AK8975/Examples/AK8975_MPUEVB_raw/AK8975_MPUEVB_raw.ino
@@ -44,9 +44,6 @@ THE SOFTWARE.
 ===============================================
 */
 
-// Arduino Wire library is required if I2Cdev I2CDEV_ARDUINO_WIRE implementation
-// is used in I2Cdev.h
-#include "Wire.h"
 
 // I2Cdev, AK8975, and MPU6050 must be installed as libraries, or else the
 // .cpp/.h files for all classes must be in the include path of your project
@@ -70,7 +67,7 @@ bool blinkState = false;
 
 void setup() {
     // join I2C bus (I2Cdev library doesn't do this automatically)
-    Wire.begin();
+    I2Cdev::begin();
 
     // initialize serial communication
     // (38400 chosen because it works as well at 8MHz as it does at 16MHz, but

--- a/Arduino/AK8975/Examples/AK8975_raw/AK8975_raw.ino
+++ b/Arduino/AK8975/Examples/AK8975_raw/AK8975_raw.ino
@@ -29,9 +29,6 @@ THE SOFTWARE.
 ===============================================
 */
 
-// Arduino Wire library is required if I2Cdev I2CDEV_ARDUINO_WIRE implementation
-// is used in I2Cdev.h
-#include "Wire.h"
 
 // I2Cdev and AK8975 must be installed as libraries, or else the .cpp/.h files
 // for both classes must be in the include path of your project
@@ -53,7 +50,7 @@ bool blinkState = false;
 
 void setup() {
     // join I2C bus (I2Cdev library doesn't do this automatically)
-    Wire.begin();
+    I2Cdev::begin();
 
     // initialize serial communication
     // (38400 chosen because it works as well at 8MHz as it does at 16MHz, but

--- a/Arduino/BMA150/examples/BMA150_raw/BMA150_raw.ino
+++ b/Arduino/BMA150/examples/BMA150_raw/BMA150_raw.ino
@@ -29,9 +29,6 @@ THE SOFTWARE.
 ===============================================
 */
 
-// Arduino Wire library is required if I2Cdev I2CDEV_ARDUINO_WIRE implementation
-// is used in I2Cdev.h
-#include "Wire.h"
 
 // I2Cdev and BMA150 must be installed as libraries, or else the .cpp/.h files
 // for both classes must be in the include path of your project
@@ -49,7 +46,7 @@ bool blinkState = false;
 
 void setup() {
     // join I2C bus (I2Cdev library doesn't do this automatically)
-    Wire.begin();
+    I2Cdev::begin();
 
     // initialize serial communication
     // (38400 chosen because it works as well at 8MHz as it does at 16MHz, but

--- a/Arduino/BMP085/Examples/BMP085_basic/BMP085_basic.ino
+++ b/Arduino/BMP085/Examples/BMP085_basic/BMP085_basic.ino
@@ -30,9 +30,6 @@ THE SOFTWARE.
 ===============================================
 */
 
-// Arduino Wire library is required if I2Cdev I2CDEV_ARDUINO_WIRE implementation
-// is used in I2Cdev.h
-#include "Wire.h"
 
 // I2Cdev and BMP085 must be installed as libraries, or else the .cpp/.h files
 // for both classes must be in the include path of your project
@@ -54,7 +51,7 @@ bool blinkState = false;
 
 void setup() {
     // join I2C bus (I2Cdev library doesn't do this automatically)
-    Wire.begin();
+    I2Cdev::begin();
 
     // initialize serial communication
     // (38400 chosen because it works as well at 8MHz as it does at 16MHz, but

--- a/Arduino/DS1307/Examples/DS1307_tick/DS1307_tick.ino
+++ b/Arduino/DS1307/Examples/DS1307_tick/DS1307_tick.ino
@@ -30,9 +30,6 @@ THE SOFTWARE.
 ===============================================
 */
 
-// Arduino Wire library is required if I2Cdev I2CDEV_ARDUINO_WIRE implementation
-// is used in I2Cdev.h
-#include "Wire.h"
 
 // I2Cdev and DS1307 must be installed as libraries, or else the .cpp/.h files
 // for both classes must be in the include path of your project
@@ -52,7 +49,7 @@ bool blinkState = false;
 
 void setup() {
     // join I2C bus (I2Cdev library doesn't do this automatically)
-    Wire.begin();
+    I2Cdev::begin();
 
     // initialize serial communication
     // (38400 chosen because it works as well at 8MHz as it does at 16MHz, but

--- a/Arduino/HMC5843/Examples/HMC5843_raw/HMC5843_raw.ino
+++ b/Arduino/HMC5843/Examples/HMC5843_raw/HMC5843_raw.ino
@@ -29,9 +29,6 @@ THE SOFTWARE.
 ===============================================
 */
 
-// Arduino Wire library is required if I2Cdev I2CDEV_ARDUINO_WIRE implementation
-// is used in I2Cdev.h
-#include "Wire.h"
 
 // I2Cdev and HMC5843 must be installed as libraries, or else the .cpp/.h files
 // for both classes must be in the include path of your project
@@ -50,7 +47,7 @@ bool blinkState = false;
 
 void setup() {
     // join I2C bus (I2Cdev library doesn't do this automatically)
-    Wire.begin();
+    I2Cdev::begin();
 
     // initialize serial communication
     // (38400 chosen because it works as well at 8MHz as it does at 16MHz, but

--- a/Arduino/HMC5883L/Examples/HMC5883L_raw/HMC5883L_raw.ino
+++ b/Arduino/HMC5883L/Examples/HMC5883L_raw/HMC5883L_raw.ino
@@ -30,9 +30,6 @@ THE SOFTWARE.
 ===============================================
 */
 
-// Arduino Wire library is required if I2Cdev I2CDEV_ARDUINO_WIRE implementation
-// is used in I2Cdev.h
-#include "Wire.h"
 
 // I2Cdev and HMC5883L must be installed as libraries, or else the .cpp/.h files
 // for both classes must be in the include path of your project
@@ -51,7 +48,7 @@ bool blinkState = false;
 
 void setup() {
     // join I2C bus (I2Cdev library doesn't do this automatically)
-    Wire.begin();
+    I2Cdev::begin();
 
     // initialize serial communication
     // (38400 chosen because it works as well at 8MHz as it does at 16MHz, but

--- a/Arduino/I2Cdev/I2Cdev.cpp
+++ b/Arduino/I2Cdev/I2Cdev.cpp
@@ -94,6 +94,24 @@ THE SOFTWARE.
 I2Cdev::I2Cdev() {
 }
 
+/** Implementation agnostic begin method. Will call Wire.begin() if arduino wire library is selected.
+ * @return Status of operation (true = success)
+ */
+bool I2Cdev::begin() {
+    #if I2CDEV_IMPLEMENTATION == I2CDEV_ARDUINO_WIRE
+    Wire.begin();
+    return true;
+    #elif I2CDEV_IMPLEMENTATION == I2CDEV_BUILTIN_FASTWIRE
+    // TODO: decide what to do here.
+    return true;
+    #elif I2CDEV_IMPLEMENTATION == I2CDEV_BUILTIN_NBWIRE
+    twi_init();
+    return true;
+    #elif I2CDEV_IMPLEMENTATION == I2CDEV_SOFTI2CMASTER_LIBRARY
+    return i2c_init();
+    #endif
+}
+
 /** Read a single bit from an 8-bit device register.
  * @param devAddr I2C slave device address
  * @param regAddr Register regAddr to read from

--- a/Arduino/I2Cdev/I2Cdev.cpp
+++ b/Arduino/I2Cdev/I2Cdev.cpp
@@ -103,6 +103,7 @@ bool I2Cdev::begin() {
     return true;
     #elif I2CDEV_IMPLEMENTATION == I2CDEV_BUILTIN_FASTWIRE
     // TODO: decide what to do here.
+    Fastwire::setup(400, true);
     return true;
     #elif I2CDEV_IMPLEMENTATION == I2CDEV_BUILTIN_NBWIRE
     twi_init();

--- a/Arduino/I2Cdev/I2Cdev.cpp
+++ b/Arduino/I2Cdev/I2Cdev.cpp
@@ -1527,3 +1527,35 @@ uint16_t I2Cdev::readTimeout = I2CDEV_DEFAULT_READ_TIMEOUT;
     }
 
 #endif
+
+#if I2CDEV_IMPLEMENTATION == I2CDEV_SOFTI2CMASTER_LIBRARY
+
+    boolean SoftI2CMasterWire::init(void){
+        return i2c_init();
+    }
+
+    bool SoftI2CMasterWire::start(uint8_t addr){
+        return(i2c_start(addr));
+    }
+    
+    void SoftI2CMasterWire::start_wait(uint8_t addr){
+        i2c_start_wait(addr);
+    }
+    
+    bool SoftI2CMasterWire::rep_start(uint8_t addr){
+        return i2c_rep_start(addr);
+    }
+    
+    void SoftI2CMasterWire::stop(void){
+        i2c_stop();
+    }
+    
+    bool SoftI2CMasterWire::write(uint8_t value){
+        return i2c_write(value);
+    }
+     
+    uint8_t SoftI2CMasterWire::read(bool last){
+        return i2c_read(last);
+    }
+    
+#endif

--- a/Arduino/I2Cdev/I2Cdev.cpp
+++ b/Arduino/I2Cdev/I2Cdev.cpp
@@ -95,21 +95,39 @@ I2Cdev::I2Cdev() {
 }
 
 /** Implementation agnostic begin method. Will call Wire.begin() if arduino wire library is selected.
+ * This is an Arduino convenience method, not part of the 'proper' I2Cdev API.
  * @return Status of operation (true = success)
  */
 bool I2Cdev::begin() {
     #if I2CDEV_IMPLEMENTATION == I2CDEV_ARDUINO_WIRE
-    Wire.begin();
-    return true;
+        #ifdef I2CDEV_SERIAL_DEBUG
+            Serial.println("I2CDEV_IMPLEMENTATION == I2CDEV_ARDUINO_WIRE");
+        #endif
+        Wire.begin();
+        return true;
     #elif I2CDEV_IMPLEMENTATION == I2CDEV_BUILTIN_FASTWIRE
-    // TODO: decide what to do here.
-    Fastwire::setup(400, true);
-    return true;
+        #ifdef I2CDEV_SERIAL_DEBUG
+            Serial.println("I2CDEV_IMPLEMENTATION == I2CDEV_BUILTIN_FASTWIRE");
+        #endif
+        Fastwire::setup(400, true);
+        return true;
     #elif I2CDEV_IMPLEMENTATION == I2CDEV_BUILTIN_NBWIRE
-    twi_init();
-    return true;
+        #ifdef I2CDEV_SERIAL_DEBUG
+            Serial.println("I2CDEV_IMPLEMENTATION == I2CDEV_BUILTIN_NBWIRE");
+        #endif
+        twi_init();
+        return true;
     #elif I2CDEV_IMPLEMENTATION == I2CDEV_SOFTI2CMASTER_LIBRARY
-    return i2c_init();
+        #ifdef I2CDEV_SERIAL_DEBUG
+            Serial.println("I2CDEV_IMPLEMENTATION == I2CDEV_SOFTI2CMASTER_LIBRARY");
+        #endif
+        return i2c_init();
+    #else
+        #ifdef I2CDEV_SERIAL_DEBUG
+            Serial.print("Unrecognised I2CDEV_IMPLEMENTATION == ");
+            Serial.println(I2CDEV_IMPLEMENTATION);
+        #endif 
+        return false;
     #endif
 }
 

--- a/Arduino/I2Cdev/I2Cdev.h
+++ b/Arduino/I2Cdev/I2Cdev.h
@@ -95,11 +95,23 @@ THE SOFTWARE.
         // 
         // The class SoftI2CMasterWire exposes the functions found in SoftI2CMaster.h.
         
-        // When using the softi2cmaster these defines are required, change as you please
-        #define SDA_PORT PORTC
-        #define SDA_PIN 4
-        #define SCL_PORT PORTC
-        #define SCL_PIN 5
+        // When using the softi2cmaster these defines are required, change as you please.
+        // There are more #defines you can set for software i2c, see SoftI2CMaster.h.
+        #ifndef SDA_PORT
+            #define SDA_PORT PORTC
+        #endif
+        
+        #ifndef SDA_PIN
+            #define SDA_PIN 4
+        #endif
+        
+        #ifndef SCL_PORT
+            #define SCL_PORT PORTC
+        #endif
+        
+        #ifndef SCL_PIN
+            #define SCL_PIN 5
+        #endif
     
     #endif
 #endif

--- a/Arduino/I2Cdev/I2Cdev.h
+++ b/Arduino/I2Cdev/I2Cdev.h
@@ -116,6 +116,7 @@ class I2Cdev {
     public:
         I2Cdev();
 
+        static bool begin();
         static int8_t readBit(uint8_t devAddr, uint8_t regAddr, uint8_t bitNum, uint8_t *data, uint16_t timeout=I2Cdev::readTimeout);
         static int8_t readBitW(uint8_t devAddr, uint8_t regAddr, uint8_t bitNum, uint16_t *data, uint16_t timeout=I2Cdev::readTimeout);
         static int8_t readBits(uint8_t devAddr, uint8_t regAddr, uint8_t bitStart, uint8_t length, uint8_t *data, uint16_t timeout=I2Cdev::readTimeout);

--- a/Arduino/I2Cdev/I2Cdev.h
+++ b/Arduino/I2Cdev/I2Cdev.h
@@ -52,6 +52,7 @@ THE SOFTWARE.
 // -----------------------------------------------------------------------------
 #ifndef I2CDEV_IMPLEMENTATION
 #define I2CDEV_IMPLEMENTATION       I2CDEV_ARDUINO_WIRE
+//#define I2CDEV_IMPLEMENTATION       I2CDEV_SOFTI2CMASTER_LIBRARY
 //#define I2CDEV_IMPLEMENTATION       I2CDEV_BUILTIN_FASTWIRE
 #endif // I2CDEV_IMPLEMENTATION
 
@@ -62,11 +63,12 @@ THE SOFTWARE.
 // -----------------------------------------------------------------------------
 // I2C interface implementation options
 // -----------------------------------------------------------------------------
-#define I2CDEV_ARDUINO_WIRE         1 // Wire object from Arduino
-#define I2CDEV_BUILTIN_NBWIRE       2 // Tweaked Wire object from Gene Knight's NBWire project
-                                      // ^^^ NBWire implementation is still buggy w/some interrupts!
-#define I2CDEV_BUILTIN_FASTWIRE     3 // FastWire object from Francesco Ferrara's project
-#define I2CDEV_I2CMASTER_LIBRARY    4 // I2C object from DSSCircuits I2C-Master Library at https://github.com/DSSCircuits/I2C-Master-Library
+#define I2CDEV_ARDUINO_WIRE           1 // Wire object from Arduino
+#define I2CDEV_BUILTIN_NBWIRE         2 // Tweaked Wire object from Gene Knight's NBWire project
+                                        // ^^^ NBWire implementation is still buggy w/some interrupts!
+#define I2CDEV_BUILTIN_FASTWIRE       3 // FastWire object from Francesco Ferrara's project
+#define I2CDEV_I2CMASTER_LIBRARY      4 // I2C object from DSSCircuits I2C-Master Library at https://github.com/DSSCircuits/I2C-Master-Library
+#define I2CDEV_SOFTI2CMASTER_LIBRARY  5 // Software based I2C library at https://github.com/felias-fogg/SoftI2CMaster
 
 // -----------------------------------------------------------------------------
 // Arduino-style "Serial.print" debug constant (uncomment to enable)
@@ -84,9 +86,20 @@ THE SOFTWARE.
         #define BUFFER_LENGTH 32
     #elif I2CDEV_IMPLEMENTATION == I2CDEV_ARDUINO_WIRE
         #include <Wire.h>
-    #endif
-    #if I2CDEV_IMPLEMENTATION == I2CDEV_I2CMASTER_LIBRARY
+    #elif I2CDEV_IMPLEMENTATION == I2CDEV_I2CMASTER_LIBRARY
         #include <I2C.h>
+    #elif I2CDEV_IMPLEMENTATION == I2CDEV_SOFTI2CMASTER_LIBRARY
+        // We can't include SoftI2CMaster.h here. The header file defines the softi2c functions.
+        // If the header file is included multiple times in a project it will generate 
+        // "multiple definition of" errors.
+        //#include <SoftI2CMaster.h>
+        
+        // when using the softi2cmaster these defines are required, change as you please
+        #define SDA_PORT PORTC
+        #define SDA_PIN 4
+        #define SCL_PORT PORTC
+        #define SCL_PIN 5
+    
     #endif
 #endif
 

--- a/Arduino/I2Cdev/I2Cdev.h
+++ b/Arduino/I2Cdev/I2Cdev.h
@@ -92,9 +92,10 @@ THE SOFTWARE.
         // We can't include SoftI2CMaster.h here. The header file defines the softi2c functions.
         // If the header file is included multiple times in a project it will generate 
         // "multiple definition of" errors.
-        //#include <SoftI2CMaster.h>
+        // 
+        // The class SoftI2CMasterWire exposes the functions found in SoftI2CMaster.h.
         
-        // when using the softi2cmaster these defines are required, change as you please
+        // When using the softi2cmaster these defines are required, change as you please
         #define SDA_PORT PORTC
         #define SDA_PIN 4
         #define SCL_PORT PORTC
@@ -291,5 +292,24 @@ class I2Cdev {
     extern TwoWire Wire;
 
 #endif // I2CDEV_IMPLEMENTATION == I2CDEV_BUILTIN_NBWIRE
+
+#if I2CDEV_IMPLEMENTATION == I2CDEV_SOFTI2CMASTER_LIBRARY
+
+    /* wrapper for SoftI2CMaster
+     * https://github.com/felias-fogg/SoftI2CMaster
+     * The library is defined in a header file, so it can only be included once in 
+     * a link unit. This wrapper exposes those functions, if needed.
+     */
+    class SoftI2CMasterWire {
+        public:
+            static boolean init(void);
+            static bool start(uint8_t addr); 
+            static void start_wait(uint8_t addr);
+            static bool rep_start(uint8_t addr);
+            static void stop(void) ;
+            static bool write(uint8_t value);
+            static uint8_t read(bool last);
+    };
+#endif // I2CDEV_IMPLEMENTATION == I2CDEV_SOFTI2CMASTER_LIBRARY
 
 #endif /* _I2CDEV_H_ */

--- a/Arduino/I2Cdev/keywords.txt
+++ b/Arduino/I2Cdev/keywords.txt
@@ -11,6 +11,7 @@ I2Cdev	KEYWORD1
 # Methods and Functions (KEYWORD2)
 #######################################
 
+begin	KEYWORD2
 readBit	KEYWORD2
 readBitW	KEYWORD2
 readBits	KEYWORD2

--- a/Arduino/IAQ2000/examples/IAQ2000/IAQ2000.ino
+++ b/Arduino/IAQ2000/examples/IAQ2000/IAQ2000.ino
@@ -31,9 +31,6 @@
   ===============================================
 */
 
-// Arduino Wire library is required if I2Cdev I2CDEV_ARDUINO_WIRE implementation
-// is used in I2Cdev.h
-#include "Wire.h"
 
 // I2Cdev and IAQ2000 must be installed as libraries, or else the .cpp/.h files
 // for both classes must be in the include path of your project
@@ -65,7 +62,7 @@ void setup() {
   // configure LED pin for output
   pinMode(LED_PIN, OUTPUT);
   // join I2C bus (I2Cdev library doesn't do this automatically)
-  Wire.begin();
+  I2Cdev::begin();
 
   // initialize serial communication
   // (38400 chosen because it works as well at 8MHz as it does at 16MHz, but

--- a/Arduino/ITG3200/Examples/ITG3200_raw/ITG3200_raw.ino
+++ b/Arduino/ITG3200/Examples/ITG3200_raw/ITG3200_raw.ino
@@ -29,9 +29,6 @@ THE SOFTWARE.
 ===============================================
 */
 
-// Arduino Wire library is required if I2Cdev I2CDEV_ARDUINO_WIRE implementation
-// is used in I2Cdev.h
-#include "Wire.h"
 
 // I2Cdev and ITG3200 must be installed as libraries, or else the .cpp/.h files
 // for both classes must be in the include path of your project
@@ -51,7 +48,7 @@ bool blinkState = false;
 
 void setup() {
     // join I2C bus (I2Cdev library doesn't do this automatically)
-    Wire.begin();
+    I2Cdev::begin();
 
     // initialize serial communication
     // (38400 chosen because it works as well at 8MHz as it does at 16MHz, but

--- a/Arduino/L3G4200D/Examples/L3G4200D_raw/L3G4200D_raw.ino
+++ b/Arduino/L3G4200D/Examples/L3G4200D_raw/L3G4200D_raw.ino
@@ -29,9 +29,6 @@ THE SOFTWARE.
 ===============================================
 */
 
-// Arduino Wire library is required if I2Cdev I2CDEV_ARDUINO_WIRE implementation
-// is used in I2Cdev.h
-#include <Wire.h>
 
 // I2Cdev and L3G4200D must be installed as libraries, or else the .cpp/.h files
 // for both classes must be in the include path of your project
@@ -49,7 +46,7 @@ bool blinkState = false;
 
 void setup() {
     // join I2C bus (I2Cdev library doesn't do this automatically)
-    Wire.begin();
+    I2Cdev::begin();
 
     // initialize serial communication
     // (38400 chosen because it works as well at 8MHz as it does at 16MHz, but

--- a/Arduino/L3GD20H/examples/L3GD20H_basic/L3GD20H_basic.ino
+++ b/Arduino/L3GD20H/examples/L3GD20H_basic/L3GD20H_basic.ino
@@ -29,9 +29,6 @@ THE SOFTWARE.
 ===============================================
 */
 
-// Arduino Wire library is required if I2Cdev I2CDEV_ARDUINO_WIRE implementation
-// is used in I2Cdev.h
-#include <Wire.h>
 
 // I2Cdev and L3GD20H must be installed as libraries, or else the .cpp/.h files
 // for both classes must be in the include path of your project
@@ -48,7 +45,7 @@ bool blinkState = false;
 
 void setup() {
     // join I2C bus (I2Cdev library doesn't do this automatically)
-    Wire.begin();
+    I2Cdev::begin();
 
     // initialize serial communication
     Serial.begin(9600);

--- a/Arduino/LSM303DLHC/examples/LSM303DLHC_test/LSM303DLHC_test.ino
+++ b/Arduino/LSM303DLHC/examples/LSM303DLHC_test/LSM303DLHC_test.ino
@@ -29,9 +29,6 @@ THE SOFTWARE.
 ===============================================
 */
 
-// Arduino Wire library is required if I2Cdev I2CDEV_ARDUINO_WIRE implementation
-// is used in I2Cdev.h
-#include <Wire.h>
 
 // I2Cdev and LSM303DLHC must be installed as libraries, or else the .cpp/.h files
 // for both classes must be in the include path of your project
@@ -50,7 +47,7 @@ bool blinkState = false;
 
 void setup() {
     // join I2C bus (I2Cdev library doesn't do this automatically)
-    Wire.begin();
+    I2Cdev::begin();
 
     // initialize serial communication
     // (38400 chosen because it works as well at 8MHz as it does at 16MHz, but

--- a/Arduino/MPU6050/Examples/MPU6050_DMP6/MPU6050_DMP6.ino
+++ b/Arduino/MPU6050/Examples/MPU6050_DMP6/MPU6050_DMP6.ino
@@ -48,12 +48,6 @@ THE SOFTWARE.
 #include "MPU6050_6Axis_MotionApps20.h"
 //#include "MPU6050.h" // not necessary if using MotionApps include file
 
-// Arduino Wire library is required if I2Cdev I2CDEV_ARDUINO_WIRE implementation
-// is used in I2Cdev.h
-#if I2CDEV_IMPLEMENTATION == I2CDEV_ARDUINO_WIRE
-    #include "Wire.h"
-#endif
-
 // class default I2C address is 0x68
 // specific I2C addresses may be passed as a parameter here
 // AD0 low = 0x68 (default for SparkFun breakout and InvenSense evaluation board)
@@ -160,11 +154,9 @@ void dmpDataReady() {
 
 void setup() {
     // join I2C bus (I2Cdev library doesn't do this automatically)
+    I2Cdev::begin();
     #if I2CDEV_IMPLEMENTATION == I2CDEV_ARDUINO_WIRE
-        Wire.begin();
         TWBR = 24; // 400kHz I2C clock (200kHz if CPU is 8MHz). Comment this line if having compilation difficulties with TWBR.
-    #elif I2CDEV_IMPLEMENTATION == I2CDEV_BUILTIN_FASTWIRE
-        Fastwire::setup(400, true);
     #endif
 
     // initialize serial communication

--- a/Arduino/MPU6050/Examples/MPU6050_DMP6_Ethernet/MPU6050_DMP6_Ethernet.ino
+++ b/Arduino/MPU6050/Examples/MPU6050_DMP6_Ethernet/MPU6050_DMP6_Ethernet.ino
@@ -41,9 +41,6 @@ THE SOFTWARE.
 #include "MPU6050_6Axis_MotionApps20.h"
 //#include "MPU6050.h" // not necessary if using MotionApps include file
 
-// Arduino Wire library is required if I2Cdev I2CDEV_ARDUINO_WIRE implementation
-// is used in I2Cdev.h
-#include "Wire.h"
 #include "avr/wdt.h"// Watchdog library
 
 // class default I2C address is 0x68
@@ -168,11 +165,9 @@ void setup() {
     // You can find more time settings at http://www.nongnu.org/avr-libc/user-manual/group__avr__watchdog.html .
     
     // join I2C bus (I2Cdev library doesn't do this automatically)
+    I2Cdev::begin();
     #if I2CDEV_IMPLEMENTATION == I2CDEV_ARDUINO_WIRE
-        Wire.begin();
         TWBR = 24; // 400kHz I2C clock (200kHz if CPU is 8MHz)
-    #elif I2CDEV_IMPLEMENTATION == I2CDEV_BUILTIN_FASTWIRE
-       Fastwire::setup(400, true);
     #endif
 
     // initialize serial communication

--- a/Arduino/MPU6050/Examples/MPU6050_raw/MPU6050_raw.ino
+++ b/Arduino/MPU6050/Examples/MPU6050_raw/MPU6050_raw.ino
@@ -36,11 +36,6 @@ THE SOFTWARE.
 #include "I2Cdev.h"
 #include "MPU6050.h"
 
-// Arduino Wire library is required if I2Cdev I2CDEV_ARDUINO_WIRE implementation
-// is used in I2Cdev.h
-#if I2CDEV_IMPLEMENTATION == I2CDEV_ARDUINO_WIRE
-    #include "Wire.h"
-#endif
 
 // class default I2C address is 0x68
 // specific I2C addresses may be passed as a parameter here
@@ -71,11 +66,7 @@ bool blinkState = false;
 
 void setup() {
     // join I2C bus (I2Cdev library doesn't do this automatically)
-    #if I2CDEV_IMPLEMENTATION == I2CDEV_ARDUINO_WIRE
-        Wire.begin();
-    #elif I2CDEV_IMPLEMENTATION == I2CDEV_BUILTIN_FASTWIRE
-        Fastwire::setup(400, true);
-    #endif
+    I2Cdev::begin();
 
     // initialize serial communication
     // (38400 chosen because it works as well at 8MHz as it does at 16MHz, but

--- a/Arduino/MPU9150/Examples/MPU9150_raw/MPU9150_raw.ino
+++ b/Arduino/MPU9150/Examples/MPU9150_raw/MPU9150_raw.ino
@@ -29,9 +29,6 @@ THE SOFTWARE.
 ===============================================
 */
 
-// Arduino Wire library is required if I2Cdev I2CDEV_ARDUINO_WIRE implementation
-// is used in I2Cdev.h
-#include "Wire.h"
 
 // I2Cdev and MPU9150 must be installed as libraries, or else the .cpp/.h files
 // for both classes must be in the include path of your project
@@ -54,7 +51,7 @@ bool blinkState = false;
 
 void setup() {
     // join I2C bus (I2Cdev library doesn't do this automatically)
-    Wire.begin();
+    I2Cdev::begin();
 
     // initialize serial communication
     // (38400 chosen because it works as well at 8MHz as it does at 16MHz, but


### PR DESCRIPTION
Added a software I2C implementation backend (https://github.com/felias-fogg/SoftI2CMaster)

I needed to run my arduino in I2C slave mode, while still being able to connect to other I2C devices in master mode (on another I2C bus) and I found this SoftI2CMaster driver that works quite well. 

The problem is that I did not want to re-write all of the driver code. The solution I came up with is to let i2cdevlib run the SoftI2CMaster in master mode, while`Wire.h`is using the hardware I2C bus in slave mode. 

SoftI2CMaster is contained inside just one header file, so it must be included only once in a project.
I included it in `I2Cdev.cpp`. The problem is then that the`i2c_init()`function is not accessible from outside  `I2Cdev.cpp`. A workaround for this is to:
* Add an Arduino convenience method `I2Cdev::begin()` that will call the correct`Wire.begin()`,`i2c_init()`,`twi_init()`etc. etc. depending on the value of I2CDEV_IMPLEMENTATION.
* Add a wrapper that exposes the functions of SoftI2CMaster in a more non-C-way.
* declare the prototypes of SoftI2CMaster in I2Cdev.h if `I2CDEV_IMPLEMENTATION==I2CDEV_SOFTI2CMASTER_LIBRARY`

I opted for the first two solutions. 

I understand that the`I2Cdev::begin()`solution can be a bit controversial, but it's not cut in stone.
What I can't use is a solution where`Wire`is redefined, because i need to use the vanilla `Wire.h` in parallel with I2Cdev.

P.S. I have not actually tested master+slave mode (I2Cdev in software master mode together with`Wire.h` in slave) yet. I've just tested that software I2Cdev works with the few devices I got (ADXL345 & ADS1115 so far).