### PR TITLE
fix MPU9150 Magnetometer data format to Little Endian

### DIFF
--- a/Arduino/MPU9150/MPU9150.cpp
+++ b/Arduino/MPU9150/MPU9150.cpp
@@ -1726,9 +1726,10 @@ void MPU9150::getMotion9(int16_t* ax, int16_t* ay, int16_t* az, int16_t* gx, int
     I2Cdev::writeByte(MPU9150_RA_MAG_ADDRESS, 0x0A, 0x01); //enable the magnetometer
     delay(10);
     I2Cdev::readBytes(MPU9150_RA_MAG_ADDRESS, MPU9150_RA_MAG_XOUT_L, 6, buffer);
-    *mx = (((int16_t)buffer[0]) << 8) | buffer[1];
-    *my = (((int16_t)buffer[2]) << 8) | buffer[3];
-    *mz = (((int16_t)buffer[4]) << 8) | buffer[5];
+    //Measurement data is stored in two's complement and Little Endian format. Measurement range of each axis is from -4096 to +4095 in decimal.
+	*mx = (int16_t)(((uint16_t)buffer[1] << 8) | (uint16_t)buffer[0]);
+	*my = (int16_t)(((uint16_t)buffer[3] << 8) | (uint16_t)buffer[2]);
+	*mz = (int16_t)(((uint16_t)buffer[5] << 8) | (uint16_t)buffer[4]);
 }
 /** Get raw 6-axis motion sensor readings (accel/gyro).
  * Retrieves all currently available motion sensor values.

--- a/Arduino/MPU9150/examples/MPU9150_raw/MPU9150_raw.ino
+++ b/Arduino/MPU9150/examples/MPU9150_raw/MPU9150_raw.ino
@@ -89,17 +89,27 @@ void loop() {
 //  Serial.print(gx); Serial.print("\t");
 //  Serial.print(gy); Serial.print("\t");
 //  Serial.print(gz); Serial.print("\t");
-    Serial.print(int(mx)*int(mx)); Serial.print("\t");
-    Serial.print(int(my)*int(my)); Serial.print("\t");
-    Serial.print(int(mz)*int(mz)); Serial.print("\t | ");
+    //Serial.print(int(mx)*int(mx)); Serial.print("\t");
+    //Serial.print(int(my)*int(my)); Serial.print("\t");
+    //Serial.print(int(mz)*int(mz)); Serial.print("\t | ");
 
-    const float N = 256;
-    float mag = mx*mx/N + my*my/N + mz*mz/N;
+    //const float N = 256;
+    //float mag = mx*mx/N + my*my/N + mz*mz/N;
 
-    Serial.print(mag); Serial.print("\t");
-    for (int i=0; i<mag; i++)
-        Serial.print("*");
-    Serial.print("\n");
+    //Serial.print(mag); Serial.print("\t");
+    //for (int i=0; i<mag; i++)
+    //    Serial.print("*");
+
+
+    //Sensitivity Scale Factor:
+    //| MIN   | TYP | MAX   | UNITS   |
+    //| 0.285 | 0.3 | 0.315 | uT /LSB |
+    //compass data in uT
+    Serial.print(mx * 0.3f); Serial.print("\t");
+    Serial.print(my * 0.3f); Serial.print("\t");
+    Serial.print(mz * 0.3f); Serial.println("\t | uT");
+
+    //Serial.print("\n");
 
     // blink LED to indicate activity
     blinkState = !blinkState;


### PR DESCRIPTION
MPU-9150 Register Map and Descriptions Revision 4.0 Document([RM-MPU-9150A-00.pdf](https://www.invensense.com/wp-content/uploads/2015/02/MPU-9150-Register-Map.pdf))
Page 56 shows:

```
Measurement data is stored in two’s complement and Little Endian format. Measurement range of each axis is from -4096 to +4095 in decimal.
```
