### PR TITLE
Fixed typo in DS1307 implementation

### DIFF
--- a/Arduino/DS1307/DS1307.cpp
+++ b/Arduino/DS1307/DS1307.cpp
@@ -435,7 +435,7 @@ void DS1307::setDateTime24(uint16_t year, uint8_t month, uint8_t day, uint8_t ho
         yOff = conv2d(date + 9);
         // Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec 
         switch (date[0]) {
-            case 'J': m = date[1] == 'a' ? 1 : m = date[2] == 'n' ? 6 : 7; break;
+            case 'J': m = (date[1] == 'a' ? 1 : (date[2] == 'n' ? 6 : 7)); break;
             case 'F': m = 2; break;
             case 'A': m = date[2] == 'r' ? 4 : 8; break;
             case 'M': m = date[2] == 'r' ? 3 : 5; break;


### PR DESCRIPTION
Fixes a simple typo (assignment within a tertiary comparison operator) in the DS1307 code.  Not tested (I don't have a device); it was found by my compiler with extra warnings turned on.