### PR TITLE
Unknown function is actually setting start address

### DIFF
--- a/Arduino/MPU6050/MPU6050_6Axis_MotionApps20.h
+++ b/Arduino/MPU6050/MPU6050_6Axis_MotionApps20.h
@@ -412,7 +412,7 @@ uint8_t MPU6050::dmpInitialize() {
             DEBUG_PRINTLN(F("Setting DMP programm start address"));
             //write start address MSB into register
             setDMPConfig1(0x03);
-            //write start adress LSB into register
+            //write start address LSB into register
             setDMPConfig2(0x00);
 
             DEBUG_PRINTLN(F("Clearing OTP Bank flag..."));

--- a/Arduino/MPU6050/MPU6050_6Axis_MotionApps20.h
+++ b/Arduino/MPU6050/MPU6050_6Axis_MotionApps20.h
@@ -409,8 +409,10 @@ uint8_t MPU6050::dmpInitialize() {
             DEBUG_PRINTLN(F("Setting gyro sensitivity to +/- 2000 deg/sec..."));
             setFullScaleGyroRange(MPU6050_GYRO_FS_2000);
 
-            DEBUG_PRINTLN(F("Setting DMP configuration bytes (function unknown)..."));
+            DEBUG_PRINTLN(F("Setting DMP programm start address"));
+            //write start address MSB into register
             setDMPConfig1(0x03);
+            //write start adress LSB into register
             setDMPConfig2(0x00);
 
             DEBUG_PRINTLN(F("Clearing OTP Bank flag..."));


### PR DESCRIPTION
Unknown function is actually setting start address of DMP, where the firmware is supposed to execute.
Source: http://www.robotrebels.org/index.php?topic=318.0

<< Register 109    (0x6D)           Bank Select Address – firmware loaded in 256 byte banks 0-11 (total 3k)
Register 110   (0x6E)      Bank Memory Address – the actual byte address within the bank
Register 111   (0x6F)      Firmware Read/Write – the portal to read and write a byte through
Register 112   (0x70)      Program Start Address H – this is where this firmware version begins to execute (0x0400) {0x0300 in our case}
Register 113   (0x71)      Program Start Address L >>