### PR TITLE
fix bug(?) in postfix-operation of "processed" pointer

### DIFF
--- a/Arduino/MPU6050/MPU6050_9Axis_MotionApps41.h
+++ b/Arduino/MPU6050/MPU6050_9Axis_MotionApps41.h
@@ -831,7 +831,7 @@ uint8_t MPU6050::dmpReadAndProcessFIFOPacket(uint8_t numPackets, uint8_t *proces
         if ((status = dmpProcessFIFOPacket(buf)) > 0) return status;
         
         // increment external process count variable, if supplied
-        if (processed != 0) *processed++;
+        if (processed != 0) (*processed)++;
     }
     return 0;
 }

--- a/Arduino/MPU9150/MPU9150_9Axis_MotionApps41.h
+++ b/Arduino/MPU9150/MPU9150_9Axis_MotionApps41.h
@@ -831,7 +831,7 @@ uint8_t MPU9150::dmpReadAndProcessFIFOPacket(uint8_t numPackets, uint8_t *proces
         if ((status = dmpProcessFIFOPacket(buf)) > 0) return status;
         
         // increment external process count variable, if supplied
-        if (processed != 0) *processed++;
+        if (processed != 0) (*processed)++;
     }
     return 0;
 }

--- a/MSP430/MPU6050/MPU6050_6Axis_MotionApps20.h
+++ b/MSP430/MPU6050/MPU6050_6Axis_MotionApps20.h
@@ -676,7 +676,7 @@ uint8_t MPU6050::dmpReadAndProcessFIFOPacket(uint8_t numPackets, uint8_t *proces
         if ((status = dmpProcessFIFOPacket(buf)) > 0) return status;
         
         // increment external process count variable, if supplied
-        if (processed != 0) *processed++;
+        if (processed != 0) (*processed)++;
     }
     return 0;
 }

--- a/MSP430/MPU6050/MPU6050_9Axis_MotionApps41.h
+++ b/MSP430/MPU6050/MPU6050_9Axis_MotionApps41.h
@@ -787,7 +787,7 @@ uint8_t MPU6050::dmpReadAndProcessFIFOPacket(uint8_t numPackets, uint8_t *proces
         if ((status = dmpProcessFIFOPacket(buf)) > 0) return status;
         
         // increment external process count variable, if supplied
-        if (processed != 0) *processed++;
+        if (processed != 0) (*processed)++;
     }
     return 0;
 }


### PR DESCRIPTION
*p++ is the same as *(p++)

gcc6 warns about this: `warning: value computed is not used`

Note: I did not see any effect, only the compiler warning...

doing `git grep -e "\*[a-zA-Z_0-9]\+[+-]\{2\}"` does not reveal apparent similar patterns. Looks like 076fa2958a75284afd7d3a6d16ab2ca6f22a01df already fixed that in one header file...

Signed-off-by: Martin Zenzes <martin.zenzes@dfki.de>