### PR TITLE
Fixed wrong type of variable

### DIFF
--- a/Arduino/MPU6050/examples/IMU_Zero/IMU_Zero.ino
+++ b/Arduino/MPU6050/examples/IMU_Zero/IMU_Zero.ino
@@ -122,7 +122,7 @@ void ForceHeader()
   { LinesOut = 99; }
     
 void GetSmoothed()
-  { int RawValue[6];
+  { int16_t RawValue[6];
     int i;
     long Sums[6];
     for (i = iAx; i <= iGz; i++)


### PR DESCRIPTION
There was a wrong type of variable RawValue and it didn't compile.