### PR TITLE
Change in the order of bytes in 'getMotion9'

### DIFF
--- a/Arduino/MPU9150/MPU9150.cpp
+++ b/Arduino/MPU9150/MPU9150.cpp
@@ -1726,9 +1726,9 @@ void MPU9150::getMotion9(int16_t* ax, int16_t* ay, int16_t* az, int16_t* gx, int
     I2Cdev::writeByte(MPU9150_RA_MAG_ADDRESS, 0x0A, 0x01); //enable the magnetometer
     delay(10);
     I2Cdev::readBytes(MPU9150_RA_MAG_ADDRESS, MPU9150_RA_MAG_XOUT_L, 6, buffer);
-    *mx = (((int16_t)buffer[0]) << 8) | buffer[1];
-    *my = (((int16_t)buffer[2]) << 8) | buffer[3];
-    *mz = (((int16_t)buffer[4]) << 8) | buffer[5];
+    *mx = (((int16_t)buffer[1]) << 8) | buffer[0];
+    *my = (((int16_t)buffer[3]) << 8) | buffer[2];
+    *mz = (((int16_t)buffer[5]) << 8) | buffer[4];
 }
 /** Get raw 6-axis motion sensor readings (accel/gyro).
  * Retrieves all currently available motion sensor values.


### PR DESCRIPTION
Shouldn't the order of bytes be as given [here](https://github.com/jrowberg/i2cdevlib/blob/master/Arduino/AK8975/AK8975.cpp), in the function ```getHeading()``` ? Or am I missing something?