### PR TITLE
BMP085/BMP180: Added polling for end of conversion bit. Updated example. Removed unnecessary float.

### DIFF
--- a/Arduino/BMP085/BMP085.cpp
+++ b/Arduino/BMP085/BMP085.cpp
@@ -167,10 +167,14 @@ void BMP085::setControl(uint8_t value) {
 /* measurement register methods */
 
 uint16_t BMP085::getMeasurement2() {
+    // wait for end of conversion
+    while(getControl() & 0x20);
     I2Cdev::readBytes(devAddr, BMP085_RA_MSB, 2, buffer);
     return ((uint16_t)buffer[0] << 8) + buffer[1];
 }
 uint32_t BMP085::getMeasurement3() {
+    // wait for end of conversion
+    while(getControl() & 0x20);
     I2Cdev::readBytes(devAddr, BMP085_RA_MSB, 3, buffer);
     return ((uint32_t)buffer[0] << 16) + ((uint16_t)buffer[1] << 8) + buffer[2];
 }

--- a/Arduino/BMP085/BMP085.cpp
+++ b/Arduino/BMP085/BMP085.cpp
@@ -228,7 +228,7 @@ uint32_t BMP085::getRawPressure() {
     return 0; // wrong measurement mode for pressure request
 }
 
-float BMP085::getPressure() {
+int32_t BMP085::getPressure() {
     /*
     Datasheet forumla
         UP = raw pressure

--- a/Arduino/BMP085/BMP085.h
+++ b/Arduino/BMP085/BMP085.h
@@ -111,7 +111,7 @@ class BMP085 {
         float       getTemperatureC();
         float       getTemperatureF();
         uint32_t    getRawPressure();
-        float       getPressure();
+        int32_t     getPressure();
         float       getAltitude(float pressure, float seaLevelPressure=101325);
 
    private:

--- a/Arduino/BMP085/examples/BMP085_basic/BMP085_basic.ino
+++ b/Arduino/BMP085/examples/BMP085_basic/BMP085_basic.ino
@@ -46,7 +46,7 @@ BMP085 barometer;
 
 float temperature;
 float pressure;
-float altitude;
+int32_t altitude;
 
 #define LED_PIN 13 // (Arduino is 13, Teensy is 11, Teensy++ is 6)
 bool blinkState = false;

--- a/Arduino/BMP085/examples/BMP085_basic/BMP085_basic.ino
+++ b/Arduino/BMP085/examples/BMP085_basic/BMP085_basic.ino
@@ -47,7 +47,6 @@ BMP085 barometer;
 float temperature;
 float pressure;
 float altitude;
-int32_t lastMicros;
 
 #define LED_PIN 13 // (Arduino is 13, Teensy is 11, Teensy++ is 6)
 bool blinkState = false;
@@ -77,16 +76,11 @@ void loop() {
     // request temperature
     barometer.setControl(BMP085_MODE_TEMPERATURE);
     
-    // wait appropriate time for conversion (4.5ms delay)
-    lastMicros = micros();
-    while (micros() - lastMicros < barometer.getMeasureDelayMicroseconds());
-
     // read calibrated temperature value in degrees Celsius
     temperature = barometer.getTemperatureC();
 
     // request pressure (3x oversampling mode, high detail, 23.5ms delay)
     barometer.setControl(BMP085_MODE_PRESSURE_3);
-    while (micros() - lastMicros < barometer.getMeasureDelayMicroseconds());
 
     // read calibrated pressure value in Pascals (Pa)
     pressure = barometer.getPressure();


### PR DESCRIPTION
(according to BMP180 datasheet and https://hwswbits.blogspot.ru/2012/09/eoc-bit-in-bosch-bmp085-i2c-registers.html)

Signed-off-by: Alexandr Zarubkin <me21@yandex.ru>