### PR TITLE
Add pointer initialization in MPU6050.cpp

### DIFF
--- a/Arduino/MPU6050/MPU6050.cpp
+++ b/Arduino/MPU6050/MPU6050.cpp
@@ -3037,7 +3037,7 @@ bool MPU6050::writeMemoryBlock(const uint8_t *data, uint16_t dataSize, uint8_t b
     setMemoryBank(bank);
     setMemoryStartAddress(address);
     uint8_t chunkSize;
-    uint8_t *verifyBuffer;
+    uint8_t *verifyBuffer=0;
     uint8_t *progBuffer=0;
     uint16_t i;
     uint8_t j;


### PR DESCRIPTION
The `uint8_t* verifyBuffer` pointer was uninitialized. I don't think this causes any problems, since 
it is only checked if verify is true, and that condition does initialize verifyBuffer elsewhere
in the code. However, it's probably safer to initialize it to `0` or `nullptr` in case some future
edit does something different.