### PR TITLE
ESP32_ESP-IDF: make the example compileable

### DIFF
--- a/ESP32_ESP-IDF/main/example.cpp
+++ b/ESP32_ESP-IDF/main/example.cpp
@@ -9,7 +9,7 @@
 #include <esp_err.h>
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
-#include "mpu6050.h"
+#include "MPU6050.h"
 #include "MPU6050_6Axis_MotionApps20.h"
 #include "sdkconfig.h"
 


### PR DESCRIPTION
Fix typo of the header file include.

Without the following error occurs.

CXX build/main/example.o
/home/nice/develop/esp32/i2cdevlib/ESP32_ESP-IDF/main/./example.cpp:12:21: fatal error: mpu6050.h: No such file or directory
compilation terminated.
make[1]: *** [/home/nice/develop/esp32/esp-idf/make/component_wrapper.mk:229: example.o] Error 1
make: *** [/home/nice/develop/esp32//esp-idf/make/project.mk:399: component-main-build] Error 2