### PR TITLE
ESP32_ESP-IDF/components/I2Cdev/I2Cdev.cpp: remove debug leftover

### DIFF
--- a/ESP32_ESP-IDF/components/I2Cdev/I2Cdev.cpp
+++ b/ESP32_ESP-IDF/components/I2Cdev/I2Cdev.cpp
@@ -149,7 +149,6 @@ int8_t I2Cdev::readBytes(uint8_t devAddr, uint8_t regAddr, uint8_t length, uint8
 bool I2Cdev::writeWord(uint8_t devAddr, uint8_t regAddr, uint16_t data){
 
 	uint8_t data1[] = {(uint8_t)(data>>8), (uint8_t)(data & 0xff)};
-	uint8_t data2[] = {(uint8_t)(data & 0xff), (uint8_t)(data>>8)};
 	writeBytes(devAddr, regAddr, 2, data1);
 	return true;
 }


### PR DESCRIPTION
Remove the unused variable:
  uint8_t data2[] = {(uint8_t)(data & 0xff), (uint8_t)(data>>8)};

Because it seems that it is a development leftover. It has just the
opponent byteorder then data1 which is used.

Without the compiler is complaining about this unused variable.

/home/nice/develop/esp32/i2cdevlib/ESP32_ESP-IDF/components/I2Cdev/./I2Cdev.cpp: In static member function 'static bool I2Cdev::writeWord(uint8_t, uint8_t, uint16_t)':
/home/nice/develop/esp32/i2cdevlib/ESP32_ESP-IDF/components/I2Cdev/./I2Cdev.cpp:152:10: warning: unused variable 'data2' [-Wunused-variable]
  uint8_t data2[] = {(uint8_t)(data & 0xff), (uint8_t)(data>>8)};