### PR TITLE
DS1307 Arduino library - build error caused by non const progmem fixed

### DIFF
--- a/Arduino/DS1307/DS1307.cpp
+++ b/Arduino/DS1307/DS1307.cpp
@@ -360,7 +360,7 @@ void DS1307::setDateTime24(uint16_t year, uint8_t month, uint8_t day, uint8_t ho
     ////////////////////////////////////////////////////////////////////////////////
     // utility code, some of this could be exposed in the DateTime API if needed
     
-    static uint8_t daysInMonth [] PROGMEM = { 31,28,31,30,31,30,31,31,30,31,30,31 };
+    static const uint8_t daysInMonth [] PROGMEM = { 31,28,31,30,31,30,31,31,30,31,30,31 };
     
     // number of days since 2000/01/01, valid for 2001..2099
     static uint16_t date2days(uint16_t y, uint8_t m, uint8_t d) {


### PR DESCRIPTION
The platform io build  shows error and wont compile without this const.
With this const it compiles and run everything ok.