### PR TITLE
Change the order of ifdef and define

### DIFF
--- a/Arduino/MPU6050/examples/MPU6050_DMP6_ESPWiFi/MPU6050_DMP6_ESPWiFi.ino
+++ b/Arduino/MPU6050/examples/MPU6050_DMP6_ESPWiFi/MPU6050_DMP6_ESPWiFi.ino
@@ -91,12 +91,7 @@ VectorInt16 aa;         // [x, y, z]            accel sensor measurements
 VectorInt16 aaReal;     // [x, y, z]            gravity-free accel sensor measurements
 VectorInt16 aaWorld;    // [x, y, z]            world-frame accel sensor measurements
 VectorFloat gravity;    // [x, y, z]            gravity vector
-#ifdef OUTPUT_READABLE_EULER
-float euler[3];         // [psi, theta, phi]    Euler angle container
-#endif
-#ifdef OUTPUT_READABLE_YAWPITCHROLL
-float ypr[3];           // [yaw, pitch, roll]   yaw/pitch/roll container and gravity vector
-#endif
+
 
 // uncomment "OUTPUT_READABLE_QUATERNION" if you want to see the actual
 // quaternion components in a [w, x, y, z] format (not best for parsing
@@ -132,6 +127,14 @@ float ypr[3];           // [yaw, pitch, roll]   yaw/pitch/roll container and gra
 // uncomment "OUTPUT_TEAPOT_OSC" if you want output that matches the
 // format used for the InvenSense teapot demo
 #define OUTPUT_TEAPOT_OSC
+
+
+#ifdef OUTPUT_READABLE_EULER
+float euler[3];         // [psi, theta, phi]    Euler angle container
+#endif
+#ifdef OUTPUT_READABLE_YAWPITCHROLL
+float ypr[3];           // [yaw, pitch, roll]   yaw/pitch/roll container and gravity vector
+#endif
 
 #define INTERRUPT_PIN 15 // use pin 15 on ESP8266
 


### PR DESCRIPTION
When you take the actual example file, and uncomment the line #define OUTPUT_READABLE_YAWPITCHROLL and try to compile this code, you get an error "ypr was not declared in this scope". This is caused by a wrong order of #define and #ifdef.
With this patch, it is possible to compile in the correct way.