### PR TITLE
Add RAM cache attribute to ISR

### DIFF
--- a/Arduino/MPU6050/examples/MPU6050_DMP6_ESPWiFi/MPU6050_DMP6_ESPWiFi.ino
+++ b/Arduino/MPU6050/examples/MPU6050_DMP6_ESPWiFi/MPU6050_DMP6_ESPWiFi.ino
@@ -146,7 +146,7 @@ const unsigned int outPort = 9999;          // remote port to receive OSC
 // ================================================================
 
 volatile bool mpuInterrupt = false;     // indicates whether MPU interrupt pin has gone high
-void dmpDataReady() {
+void ICACHE_RAM_ATTR dmpDataReady() {
     mpuInterrupt = true;
 }
 


### PR DESCRIPTION
Required starting with ESP8266 board package 2.5.1. Link to discussion: https://github.com/esp8266/Arduino/pull/5995

Fixes https://github.com/jrowberg/i2cdevlib/issues/443