### PR TITLE
 Improved Offset Generation for Both Gyro & Accel

### DIFF
--- a/Arduino/MPU6050/MPU6050.cpp
+++ b/Arduino/MPU6050/MPU6050.cpp
@@ -3212,7 +3212,7 @@ void MPU6050::setDMPConfig2(uint8_t config) {
 /**
   @brief      Fully calibrate Gyro from ZERO in about 6-7 Loops 600-700 readings
 */
-void MPU6050::CalibrateGyro(int Loops = 6) {
+void MPU6050::CalibrateGyro(uint16_t Loops = 6) {
   int16_t Reading, Offset;
   float Error, PTerm, ITerm[3];
   double kP = 0.3;

--- a/Arduino/MPU6050/MPU6050.cpp
+++ b/Arduino/MPU6050/MPU6050.cpp
@@ -3228,7 +3228,7 @@ void MPU6050::CalibrateGyro(int Loops = 6) {
 /**
   @brief      Fully calibrate Accel from ZERO in about 6-7 Loops 600-700 readings
 */
-void MPU6050::CalibrateAccel(int Loops = 6) {
+void MPU6050::CalibrateAccel(uint16_t Loops = 6) {
 //  int16_t Reading, Offset;
 //  float Error, PTerm, ITerm[3];
   double kP = 0.15;
@@ -3242,26 +3242,30 @@ void MPU6050::CalibrateAccel(int Loops = 6) {
 
 void MPU6050::PID(uint8_t ReadAddress, uint8_t SaveAddress, float kP,float kI, uint8_t Loops) {
   int16_t Reading, Offset;
+  int16_t BitZero[3];
   float Error, PTerm, ITerm[3];
-  float x;
   for (int i = 0; i < 3; i++) {
-	I2Cdev::readWords(devAddr, SaveAddress + (i * 2), 1, &Reading); // reads 1 or more 16 bit integers (Word)
-//    MPUi2cReadInt(SaveAddress + (i * 2), &Reading); // XG_OFFSET_H_READ: Load the active Gyro offset to fine tune
-    ITerm[i] = Reading * 8;
+    I2Cdev::readWords(devAddr, SaveAddress + (i * 2), 1, &Reading); // reads 1 or more 16 bit integers (Word)
+    if(SaveAddress != 0x13){
+      BitZero[i] = Reading & 1; // Capture Bit Zero to properly handle Accelerometer calibration
+      ITerm[i] = ((int16_t)Reading / 2) * 16; // remove bit 0 while keeping +- bit
+    } else ITerm[i] = Reading * 4; // Gyro Offset Capture
+    
   }
   for (int L = 0; L < Loops; L++) {
     for (int c = 0; c < 100; c++) {// 100 PI Calculations
       for (int i = 0; i < 3; i++) {
-		I2Cdev::readWords(devAddr, ReadAddress + (i * 2), 1, &Reading); // reads 1 or more 16 bit integers (Word)
-//        MPUi2cReadInt(ReadAddress + (i * 2), &Reading);
+	I2Cdev::readWords(devAddr, ReadAddress + (i * 2), 1, &Reading); // reads 1 or more 16 bit integers (Word)
         if ((ReadAddress == 0x3B)&&(i == 2)) Reading -= 16384; //remove Gravity
         if (abs(Reading) < 25000) {
           Error = 0 - Reading ;
           PTerm = kP * Error;
           ITerm[i] += Error * 0.002 * kI; // Integral term 1000 Calculations a second = 0.001
-          Offset = round((PTerm + ITerm[i] ) / 8); //Compute PID Output
-		  I2Cdev::writeWords(devAddr, SaveAddress + (i * 2), 1,  &Offset);
-        //  MPUi2cWriteInt(SaveAddress + (i * 2), Offset);
+          if(SaveAddress != 0x13){
+	    Offset = round((PTerm + ITerm[i] ) / 16); //Compute PID Output Accel
+	    Offset = (Offset * 2) | BitZero[i]; // Insert Bit0 Saved at beginning Shift Everything 1 Bit keeping +-
+	  } else Offset = round((PTerm + ITerm[i] ) / 4); //Compute PID Output Gyro
+	  I2Cdev::writeWords(devAddr, SaveAddress + (i * 2), 1,  &Offset);
         }
       }
       delay(1);
@@ -3270,18 +3274,21 @@ void MPU6050::PID(uint8_t ReadAddress, uint8_t SaveAddress, float kP,float kI, u
     kP *= .95;
     kI *= .95;
     for (int i = 0; i < 3; i++){
-	 Offset = round((ITerm[i]) / 8);
-	 I2Cdev::writeWords(devAddr, SaveAddress + (i * 2), 1, &Offset );
-	// MPUi2cWriteInt(SaveAddress + (i * 2), round((ITerm[i]) / 8)); // ITerm is more of a running total rather than a reaction.
-	}
+      if(SaveAddress != 0x13) {
+        Offset = round((ITerm[i] ) / 16); //Set Offset Accel 
+        Offset = (Offset * 2) | BitZero[i];  // Shift Accel Offset by 1 bit and Insert Bit0 Stored earlier
+      } else Offset = round((ITerm[i]) / 4); //Set Offset Gyro
+      I2Cdev::writeWords(devAddr, SaveAddress + (i * 2), 1, &Offset );
+    }
   }
   resetFIFO();
   resetDMP();
 }
+
 #define printfloatx(Name,Variable,Spaces,Precision,EndTxt)  Serial.print(F(Name)); {char S[(Spaces + Precision + 3)];Serial.print(F(" ")); Serial.print(dtostrf((float)Variable,Spaces,Precision ,S));}Serial.print(F(EndTxt));//Name,Variable,Spaces,Precision,EndTxt
 void MPU6050::PrintActiveOffsets() {
 	int16_t Data[3];
-	Serial.print(F("//       X Accel  Y Accel  Z Accel   X Gyro   Y Gyro   Z Gyro\nOFFSETS   "));
+	Serial.print(F("\n//                X Accel  Y Accel  Z Accel   X Gyro   Y Gyro   Z Gyro\n//#define OFFSETS "));
 	I2Cdev::readWords(devAddr, 0x06, 3, Data); 
 //	A_OFFSET_H_READ_A_OFFS(Data);
 	printfloatx("", Data[0], 5, 0, ",  ");


### PR DESCRIPTION
Gyro Calibration is now more accurate, My divisor was /8. I Changed it to /4. 
Note that the ITerm is a floating point number so dividing is more accurate than converting to integer and bit shifting >>3 or >>4.
Accel offset storage is also corrected to preserve Bit 0 Which is marked reserved in all the documentation. This could be the temperature compensation bit but I an finding little documentation about it. I didn't notice much improvement by preserving this bit with the MPU6050 but it isn't supposed to be changed so I'm preserving it.
NOTE: I tested the Accel Calibration on the MPU9250 (aka MPU6500 with a magnetometer) and failed to set any calibration values that made sense. Gurr! It seems that with the MPU9250, leaving the Accel Calibration at Factory Values and only Calibrating the Gyro provides the most accurate, stable Yaw Pitch and Roll Values. I am Searching for any hopefully working MPU9250 accelerometer calibration code to discover why my attempts are in vain.