### PR TITLE
Adding STM32duino softwire to the I2CDEV_IMPLEMETATIONs

### DIFF
--- a/Arduino/I2Cdev/I2Cdev.cpp
+++ b/Arduino/I2Cdev/I2Cdev.cpp
@@ -45,7 +45,7 @@ THE SOFTWARE.
 
 #include "I2Cdev.h"
 
-#if I2CDEV_IMPLEMENTATION == I2CDEV_ARDUINO_WIRE || I2CDEV_IMPLEMENTATION == I2CDEV_BUILTIN_SBWIRE
+#if I2CDEV_IMPLEMENTATION == I2CDEV_ARDUINO_WIRE || I2CDEV_IMPLEMENTATION == I2CDEV_BUILTIN_SBWIRE || I2CDEV_IMPLEMENTATION == I2CDEV_ARDUINO_SOFTWIRE
 
     #ifdef I2CDEV_IMPLEMENTATION_WARNINGS
         #if ARDUINO < 100
@@ -85,6 +85,9 @@ THE SOFTWARE.
     // Originally offered to the i2cdevlib project at http://arduino.cc/forum/index.php/topic,68210.30.html
     TwoWire Wire;
 
+#endif
+#if I2CDEV_IMPLEMENTATION == I2CDEV_ARDUINO_SOFTWIRE
+    SoftWire SWire;
 #endif
 
 #ifndef BUFFER_LENGTH
@@ -222,7 +225,7 @@ int8_t I2Cdev::readBytes(uint8_t devAddr, uint8_t regAddr, uint8_t length, uint8
     int8_t count = 0;
     uint32_t t1 = millis();
 
-    #if (I2CDEV_IMPLEMENTATION == I2CDEV_ARDUINO_WIRE || I2CDEV_IMPLEMENTATION == I2CDEV_BUILTIN_SBWIRE)
+    #if (I2CDEV_IMPLEMENTATION == I2CDEV_ARDUINO_WIRE || I2CDEV_IMPLEMENTATION == I2CDEV_BUILTIN_SBWIRE || I2CDEV_IMPLEMENTATION == I2CDEV_ARDUINO_SOFTWIRE)
 
         #if (ARDUINO < 100)
             // Arduino v00xx (before v1.0), Wire library
@@ -342,7 +345,7 @@ int8_t I2Cdev::readWords(uint8_t devAddr, uint8_t regAddr, uint8_t length, uint1
     int8_t count = 0;
     uint32_t t1 = millis();
 
-#if I2CDEV_IMPLEMENTATION == I2CDEV_ARDUINO_WIRE || I2CDEV_IMPLEMENTATION == I2CDEV_BUILTIN_SBWIRE
+#if I2CDEV_IMPLEMENTATION == I2CDEV_ARDUINO_WIRE || I2CDEV_IMPLEMENTATION == I2CDEV_BUILTIN_SBWIRE || I2CDEV_IMPLEMENTATION == I2CDEV_ARDUINO_SOFTWIRE
 
         #if (ARDUINO < 100)
             // Arduino v00xx (before v1.0), Wire library
@@ -596,11 +599,12 @@ bool I2Cdev::writeBytes(uint8_t devAddr, uint8_t regAddr, uint8_t length, uint8_
         Serial.print("...");
     #endif
     uint8_t status = 0;
-    #if ((I2CDEV_IMPLEMENTATION == I2CDEV_ARDUINO_WIRE && ARDUINO < 100) || I2CDEV_IMPLEMENTATION == I2CDEV_BUILTIN_NBWIRE)
+    #if ((I2CDEV_IMPLEMENTATION == I2CDEV_ARDUINO_WIRE && ARDUINO < 100) || I2CDEV_IMPLEMENTATION == I2CDEV_BUILTIN_NBWIRE || (I2CDEV_IMPLEMENTATION == I2CDEV_ARDUINO_SOFTWIRE && ARDUINO < 100))
         Wire.beginTransmission(devAddr);
         Wire.send((uint8_t) regAddr); // send address
 	#elif (I2CDEV_IMPLEMENTATION == I2CDEV_ARDUINO_WIRE && ARDUINO >= 100 \
-			|| I2CDEV_IMPLEMENTATION == I2CDEV_BUILTIN_SBWIRE && ARDUINO >= 100)
+			|| I2CDEV_IMPLEMENTATION == I2CDEV_BUILTIN_SBWIRE && ARDUINO >= 100 \
+			|| I2CDEV_IMPLEMENTATION == I2CDEV_ARDUINO_SOFTWIRE && ARDUINO >= 100)
         Wire.beginTransmission(devAddr);
         Wire.write((uint8_t) regAddr); // send address
     #elif (I2CDEV_IMPLEMENTATION == I2CDEV_BUILTIN_FASTWIRE)
@@ -612,19 +616,21 @@ bool I2Cdev::writeBytes(uint8_t devAddr, uint8_t regAddr, uint8_t length, uint8_
             Serial.print(data[i], HEX);
             if (i + 1 < length) Serial.print(" ");
         #endif
-        #if ((I2CDEV_IMPLEMENTATION == I2CDEV_ARDUINO_WIRE && ARDUINO < 100) || I2CDEV_IMPLEMENTATION == I2CDEV_BUILTIN_NBWIRE)
+        #if ((I2CDEV_IMPLEMENTATION == I2CDEV_ARDUINO_WIRE && ARDUINO < 100) || I2CDEV_IMPLEMENTATION == I2CDEV_BUILTIN_NBWIRE|| (I2CDEV_IMPLEMENTATION == I2CDEV_ARDUINO_SOFTWIRE && ARDUINO < 100))
             Wire.send((uint8_t) data[i]);
 			#elif (I2CDEV_IMPLEMENTATION == I2CDEV_ARDUINO_WIRE && ARDUINO >= 100 \
-			|| I2CDEV_IMPLEMENTATION == I2CDEV_BUILTIN_SBWIRE && ARDUINO >= 100)
+			|| I2CDEV_IMPLEMENTATION == I2CDEV_BUILTIN_SBWIRE && ARDUINO >= 100 \
+			|| I2CDEV_IMPLEMENTATION == I2CDEV_ARDUINO_SOFTWIRE && ARDUINO >= 100)
 			Wire.write((uint8_t) data[i]);
         #elif (I2CDEV_IMPLEMENTATION == I2CDEV_BUILTIN_FASTWIRE)
             Fastwire::write((uint8_t) data[i]);
         #endif
     }
-    #if ((I2CDEV_IMPLEMENTATION == I2CDEV_ARDUINO_WIRE && ARDUINO < 100) || I2CDEV_IMPLEMENTATION == I2CDEV_BUILTIN_NBWIRE)
+    #if ((I2CDEV_IMPLEMENTATION == I2CDEV_ARDUINO_WIRE && ARDUINO < 100) || I2CDEV_IMPLEMENTATION == I2CDEV_BUILTIN_NBWIRE || (I2CDEV_IMPLEMENTATION == I2CDEV_ARDUINO_SOFTWIRE && ARDUINO < 100))
         Wire.endTransmission();
 		#elif (I2CDEV_IMPLEMENTATION == I2CDEV_ARDUINO_WIRE && ARDUINO >= 100 \
-			|| I2CDEV_IMPLEMENTATION == I2CDEV_BUILTIN_SBWIRE && ARDUINO >= 100)
+			|| I2CDEV_IMPLEMENTATION == I2CDEV_BUILTIN_SBWIRE && ARDUINO >= 100 \
+			|| I2CDEV_IMPLEMENTATION == I2CDEV_ARDUINO_SOFTWIRE && ARDUINO >= 100)
 	status = Wire.endTransmission();
     #elif (I2CDEV_IMPLEMENTATION == I2CDEV_BUILTIN_FASTWIRE)
         Fastwire::stop();
@@ -654,39 +660,42 @@ bool I2Cdev::writeWords(uint8_t devAddr, uint8_t regAddr, uint8_t length, uint16
         Serial.print("...");
     #endif
     uint8_t status = 0;
-    #if ((I2CDEV_IMPLEMENTATION == I2CDEV_ARDUINO_WIRE && ARDUINO < 100) || I2CDEV_IMPLEMENTATION == I2CDEV_BUILTIN_NBWIRE)
+    #if ((I2CDEV_IMPLEMENTATION == I2CDEV_ARDUINO_WIRE && ARDUINO < 100) || I2CDEV_IMPLEMENTATION == I2CDEV_BUILTIN_NBWIRE || (I2CDEV_IMPLEMENTATION == I2CDEV_ARDUINO_SOFTWIRE && ARDUINO < 100))
         Wire.beginTransmission(devAddr);
         Wire.send(regAddr); // send address
 	#elif (I2CDEV_IMPLEMENTATION == I2CDEV_ARDUINO_WIRE && ARDUINO >= 100 \
-			|| I2CDEV_IMPLEMENTATION == I2CDEV_BUILTIN_SBWIRE && ARDUINO >= 100)
+			|| I2CDEV_IMPLEMENTATION == I2CDEV_BUILTIN_SBWIRE && ARDUINO >= 100 \
+			|| I2CDEV_IMPLEMENTATION == I2CDEV_ARDUINO_SOFTWIRE && ARDUINO >= 100)
 	Wire.beginTransmission(devAddr);
         Wire.write(regAddr); // send address
     #elif (I2CDEV_IMPLEMENTATION == I2CDEV_BUILTIN_FASTWIRE)
         Fastwire::beginTransmission(devAddr);
         Fastwire::write(regAddr);
     #endif
-    for (uint8_t i = 0; i < length; i++) { 
+    for (uint8_t i = 0; i < length * 2; i++) {
         #ifdef I2CDEV_SERIAL_DEBUG
             Serial.print(data[i], HEX);
             if (i + 1 < length) Serial.print(" ");
         #endif
-        #if ((I2CDEV_IMPLEMENTATION == I2CDEV_ARDUINO_WIRE && ARDUINO < 100) || I2CDEV_IMPLEMENTATION == I2CDEV_BUILTIN_NBWIRE)
+        #if ((I2CDEV_IMPLEMENTATION == I2CDEV_ARDUINO_WIRE && ARDUINO < 100) || I2CDEV_IMPLEMENTATION == I2CDEV_BUILTIN_NBWIRE || (I2CDEV_IMPLEMENTATION == I2CDEV_ARDUINO_SOFTWIRE && ARDUINO < 100))
             Wire.send((uint8_t)(data[i] >> 8));     // send MSB
-            Wire.send((uint8_t)data[i]);          // send LSB
+            Wire.send((uint8_t)data[i++]);          // send LSB
 		#elif (I2CDEV_IMPLEMENTATION == I2CDEV_ARDUINO_WIRE && ARDUINO >= 100 \
-			|| I2CDEV_IMPLEMENTATION == I2CDEV_BUILTIN_SBWIRE && ARDUINO >= 100)
+			|| I2CDEV_IMPLEMENTATION == I2CDEV_BUILTIN_SBWIRE && ARDUINO >= 100 \
+			|| I2CDEV_IMPLEMENTATION == I2CDEV_ARDUINO_SOFTWIRE && ARDUINO >= 100)
 			Wire.write((uint8_t)(data[i] >> 8));    // send MSB
-            Wire.write((uint8_t)data[i]);         // send LSB
+            Wire.write((uint8_t)data[i++]);         // send LSB
         #elif (I2CDEV_IMPLEMENTATION == I2CDEV_BUILTIN_FASTWIRE)
             Fastwire::write((uint8_t)(data[i] >> 8));       // send MSB
-            status = Fastwire::write((uint8_t)data[i]);   // send LSB
+            status = Fastwire::write((uint8_t)data[i++]);   // send LSB
             if (status != 0) break;
         #endif
     }
-    #if ((I2CDEV_IMPLEMENTATION == I2CDEV_ARDUINO_WIRE && ARDUINO < 100) || I2CDEV_IMPLEMENTATION == I2CDEV_BUILTIN_NBWIRE)
+    #if ((I2CDEV_IMPLEMENTATION == I2CDEV_ARDUINO_WIRE && ARDUINO < 100) || I2CDEV_IMPLEMENTATION == I2CDEV_BUILTIN_NBWIRE || (I2CDEV_IMPLEMENTATION == I2CDEV_ARDUINO_SOFTWIRE && ARDUINO < 100))
         Wire.endTransmission();
 		#elif (I2CDEV_IMPLEMENTATION == I2CDEV_ARDUINO_WIRE && ARDUINO >= 100 \
-			|| I2CDEV_IMPLEMENTATION == I2CDEV_BUILTIN_SBWIRE && ARDUINO >= 100)
+			|| I2CDEV_IMPLEMENTATION == I2CDEV_BUILTIN_SBWIRE && ARDUINO >= 100 \
+			|| I2CDEV_IMPLEMENTATION == I2CDEV_ARDUINO_SOFTWIRE && ARDUINO >= 100)
 	status = Wire.endTransmission();
     #elif (I2CDEV_IMPLEMENTATION == I2CDEV_BUILTIN_FASTWIRE)
         Fastwire::stop();

--- a/Arduino/I2Cdev/I2Cdev.h
+++ b/Arduino/I2Cdev/I2Cdev.h
@@ -54,6 +54,7 @@ THE SOFTWARE.
 #define I2CDEV_IMPLEMENTATION       I2CDEV_ARDUINO_WIRE
 //#define I2CDEV_IMPLEMENTATION       I2CDEV_BUILTIN_SBWIRE
 //#define I2CDEV_IMPLEMENTATION       I2CDEV_BUILTIN_FASTWIRE
+//#define I2CDEV_IMPLEMENTATION       I2CDEV_ARDUINO_SOFTWIRE
 #endif // I2CDEV_IMPLEMENTATION
 
 // comment this out if you are using a non-optimal IDE/implementation setting
@@ -69,6 +70,7 @@ THE SOFTWARE.
 #define I2CDEV_BUILTIN_FASTWIRE     3 // FastWire object from Francesco Ferrara's project
 #define I2CDEV_I2CMASTER_LIBRARY    4 // I2C object from DSSCircuits I2C-Master Library at https://github.com/DSSCircuits/I2C-Master-Library
 #define I2CDEV_BUILTIN_SBWIRE	    5 // I2C object from Shuning (Steve) Bian's SBWire Library at https://github.com/freespace/SBWire 
+#define I2CDEV_ARDUINO_SOFTWIRE     6 // SoftWire object from STM32duino, fall back on arduino wire for non-STM32
 
 // -----------------------------------------------------------------------------
 // Arduino-style "Serial.print" debug constant (uncomment to enable)
@@ -90,6 +92,16 @@ THE SOFTWARE.
 	#if I2CDEV_IMPLEMENTATION == I2CDEV_BUILTIN_SBWIRE
 		#include "SBWire.h"
 	#endif
+    #if I2CDEV_IMPLEMENTATION == I2CDEV_ARDUINO_SOFTWIRE
+        #ifdef ARDUINO_ARCH_STM32
+            #include <SoftWire.h>
+            #define _TWOWIRE_H_
+            extern SoftWire SWire;
+            #define Wire SWire
+        #else // ARDUINO_ARCH_STM32
+            #include <Wire.h>
+        #endif // ARDUINO_ARCH_STM32
+    #endif
 #endif
 
 #ifdef SPARK


### PR DESCRIPTION
Since I couldn't get Wire to work on my STM32, I've added stm32duino's SoftWire support to your library.  It falls back to regular Wire on non-STM32 platforms.  It is mostly ifdef stuff with a little bit of glue.  I have tested it and it is working fine.