### PR TITLE
Added dependency on Wire

### DIFF
--- a/Arduino/I2Cdev/library.json
+++ b/Arduino/I2Cdev/library.json
@@ -9,5 +9,10 @@
     "url": "https://github.com/jrowberg/i2cdevlib.git"
   },
   "frameworks": "arduino",
-  "platforms": "atmelavr"
+  "platforms": "atmelavr",
+   "dependencies": [
+     {
+        "name": "Wire"
+     }
+  ]
 }


### PR DESCRIPTION
I2Cdevlib-Core won't compile in platformIO