### PR TITLE
Fast Wire Library is now fixed.

### DIFF
--- a/Arduino/I2Cdev/I2Cdev.cpp
+++ b/Arduino/I2Cdev/I2Cdev.cpp
@@ -451,11 +451,9 @@ int8_t I2Cdev::readWords(uint8_t devAddr, uint8_t regAddr, uint8_t length, uint1
         // Fastwire library
         // no loop required for fastwire
     	uint8_t intermediate[(uint8_t)length*2];
-
 	uint8_t status = Fastwire::readBuf(devAddr << 1, regAddr, intermediate, (uint8_t)(length * 2));
-	
         if (status == 0) {
-            count = length; // success. length = Number of words read.
+            count = length; // success
             for (uint8_t i = 0; i < length; i++) {
                 data[i] = (intermediate[2*i] << 8) | intermediate[2*i + 1];
             }
@@ -669,8 +667,6 @@ bool I2Cdev::writeWords(uint8_t devAddr, uint8_t regAddr, uint8_t length, uint16
         Fastwire::beginTransmission(devAddr);
         Fastwire::write(regAddr);
     #endif
-    //Here length refers to the number of words.
-    //We are processing two bytes at a time which is equal to one word.
     for (uint8_t i = 0; i < length; i++) { 
         #ifdef I2CDEV_SERIAL_DEBUG
             Serial.print(data[i], HEX);

--- a/Arduino/I2Cdev/I2Cdev.cpp
+++ b/Arduino/I2Cdev/I2Cdev.cpp
@@ -450,12 +450,9 @@ int8_t I2Cdev::readWords(uint8_t devAddr, uint8_t regAddr, uint8_t length, uint1
 
         // Fastwire library
         // no loop required for fastwire
-	
-        //uint16_t intermediate[(uint8_t)length];	//***********************Change this line
     	uint8_t intermediate[(uint8_t)length*2];
-	
-	//uint8_t status = Fastwire::readBuf(devAddr << 1, regAddr, (uint8_t *)intermediate, (uint8_t)(length * 2));	//******************Change this line
-    	uint8_t status = Fastwire::readBuf(devAddr << 1, regAddr, intermediate, (uint8_t)(length * 2));
+
+	uint8_t status = Fastwire::readBuf(devAddr << 1, regAddr, intermediate, (uint8_t)(length * 2));
 	
         if (status == 0) {
             count = length; // success. length = Number of words read.


### PR DESCRIPTION
Operations done on "intermediate" array in loop were in conflict with its size. I have also tested it with MPU6050 DMP6 example to verify it.