### PR TITLE
Added a parameter to define the Timeout of GetCurrentFIFOPacket

### DIFF
--- a/Arduino/MPU6050/MPU6050.cpp
+++ b/Arduino/MPU6050/MPU6050.cpp
@@ -2768,8 +2768,8 @@ void MPU6050::setFIFOTimeout(uint32_t fifoTimeout) {
      int16_t fifoC;
      // This section of code is for when we allowed more than 1 packet to be acquired
      uint32_t BreakTimer = micros();
+     bool packetReceived = false;
      do {
-         if ((micros() - BreakTimer) > (getFIFOTimeout())) return 0;
          if ((fifoC = getFIFOCount())  > length) {
 
              if (fifoC > 200) { // if you waited to get the FIFO buffer to > 200 bytes it will take longer to get the last packet in the FIFO Buffer than it will take to  reset the buffer and wait for the next to arrive
@@ -2791,8 +2791,9 @@ void MPU6050::setFIFOTimeout(uint32_t fifoTimeout) {
          }
          if (!fifoC) return 0; // Called too early no data or we timed out after FIFO Reset
          // We have 1 packet
-        
-     } while (fifoC != length);
+         packetReceived = fifoC == length;
+         if (!packetReceived && (micros() - BreakTimer) > (getFIFOTimeout())) return 0;
+     } while (!packetReceived);
      getFIFOBytes(data, length); //Get 1 packet
      return 1;
 }

--- a/Arduino/MPU6050/MPU6050.h
+++ b/Arduino/MPU6050/MPU6050.h
@@ -431,6 +431,8 @@ THE SOFTWARE.
 #define MPU6050_DMP_MEMORY_BANK_SIZE    256
 #define MPU6050_DMP_MEMORY_CHUNK_SIZE   16
 
+#define MPU6050_FIFO_DEFAULT_TIMEOUT 11000
+
 // note: DMP code memory blocks defined at end of header file
 
 class MPU6050 {
@@ -717,6 +719,8 @@ class MPU6050 {
 		int8_t GetCurrentFIFOPacket(uint8_t *data, uint8_t length);
         void setFIFOByte(uint8_t data);
         void getFIFOBytes(uint8_t *data, uint8_t length);
+        void setFIFOTimeout(uint32_t fifoTimeout);
+        uint32_t getFIFOTimeout();
 
         // WHO_AM_I register
         uint8_t getDeviceID();
@@ -1032,6 +1036,7 @@ class MPU6050 {
     private:
         uint8_t devAddr;
         uint8_t buffer[14];
+        uint32_t fifoTimeout = MPU6050_FIFO_DEFAULT_TIMEOUT;
     #if defined(MPU6050_INCLUDE_DMP_MOTIONAPPS20) or defined(MPU6050_INCLUDE_DMP_MOTIONAPPS41)
         uint8_t *dmpPacketBuffer;
         uint16_t dmpPacketSize;


### PR DESCRIPTION
I added the possibility to define the timeout value because if insufficient, the "GetCurrentFIFOPacket" method cannot be used.
For example, I drive brushless motors and to reduce the audible frequency, I increased the frequency of timer 0 (TCCR0B) and the values ​​of micros() and millis() are multiplied by 64.