### PR TITLE
Allow MPU6050 suport (including DMP) for Arduino to compile on ESP32 with Arduino core 

### DIFF
--- a/Arduino/MPU6050/MPU6050.h
+++ b/Arduino/MPU6050/MPU6050.h
@@ -44,6 +44,11 @@ THE SOFTWARE.
 
 #ifdef __AVR__
 #include <avr/pgmspace.h>
+#elif defined(ESP32)
+    #include <pgmspace.h>
+    #ifndef BUFFER_LENGTH
+        #define BUFFER_LENGTH 32
+    #endif
 #else
 //#define PROGMEM /* empty */
 //#define pgm_read_byte(x) (*(x))

--- a/Arduino/MPU6050/MPU6050_6Axis_MotionApps20.h
+++ b/Arduino/MPU6050/MPU6050_6Axis_MotionApps20.h
@@ -47,6 +47,8 @@ THE SOFTWARE.
 // http://forum.arduino.cc/index.php?topic=129407.0
 #ifdef __AVR__
     #include <avr/pgmspace.h>
+#elif defined(ESP32)
+    #include <pgmspace.h>
 #else
     // Teensy 3.0 library conditional PROGMEM code from Paul Stoffregen
     #ifndef __PGMSPACE_H_

--- a/Arduino/MPU6050/MPU6050_6Axis_MotionApps_V6_12.h
+++ b/Arduino/MPU6050/MPU6050_6Axis_MotionApps_V6_12.h
@@ -49,7 +49,9 @@ THE SOFTWARE.
 // Tom Carpenter's conditional PROGMEM code
 // http://forum.arduino.cc/index.php?topic=129407.0
 #ifdef __AVR__
-    #include <avr/pgmspace.h>
+    #include <avr/pgmspace.h>.
+#elif defined(ESP32)
+    #include <pgmspace.h>
 #else
     // Teensy 3.0 library conditional PROGMEM code from Paul Stoffregen
     #ifndef __PGMSPACE_H_

--- a/Arduino/MPU6050/MPU6050_6Axis_MotionApps_V6_12.h
+++ b/Arduino/MPU6050/MPU6050_6Axis_MotionApps_V6_12.h
@@ -49,7 +49,7 @@ THE SOFTWARE.
 // Tom Carpenter's conditional PROGMEM code
 // http://forum.arduino.cc/index.php?topic=129407.0
 #ifdef __AVR__
-    #include <avr/pgmspace.h>.
+    #include <avr/pgmspace.h>
 #elif defined(ESP32)
     #include <pgmspace.h>
 #else

--- a/Arduino/MPU6050/MPU6050_9Axis_MotionApps41.h
+++ b/Arduino/MPU6050/MPU6050_9Axis_MotionApps41.h
@@ -45,6 +45,8 @@ THE SOFTWARE.
 // http://forum.arduino.cc/index.php?topic=129407.0
 #ifdef __AVR__
     #include <avr/pgmspace.h>
+#elif defined(ESP32)
+    #include <pgmspace.h>
 #else
     // Teensy 3.0 library conditional PROGMEM code from Paul Stoffregen
     #ifndef __PGMSPACE_H_


### PR DESCRIPTION
This is a tiny change which allows MPU6050 support library to compile on ESP32 with Arduino core. It also allows to compile DMP support and run the MotionApps examples on ESP32. I have verified this on hardware, everything works very well. This practical fixes #500

Changes are only small and related to 2 compilation problems:

Things related to progmem being redecalerd in MPU6050_..Axis_MotionApps_... header files. The code in those 3 files assumes that when`__AVR__` is not defined, it should be defining those for Teensy. 
ESP32 has those defined in progmem.h (which is usually already included, but in order to make the change easier to understand and the conde seflexplanatory I have also included the #include progmem.h directive). As a side note: there was already ` #ifndef __PGMSPACE_H_` in the code in order to prevent double definitions. But ESP32 Arduino code uses `#define PGMSPACE_INCLUDE` instead of  `#define __PGMSPACE_H_` in their progmem.h.

Another change is missing BUFFER_LENGHT. The only remark regarding this I have that there is already similar #ifndef in I2Cdev.cpp:90 . So maybe it would make sense to have this in i2cdev.h instead. I chose the approach in this PR mainly because i don't know the library well and I am trying to minimize a risk of some regression I couldn't foresee.

This PR fixes #500 as it states in the description (there is a lot of discussion which talks about other boards, but the issue itself was created for particular compilation problems  I am proposing to fix in this PR.
