### PR TITLE
Fixed MPU6050 compilation error on Maixduino platform

### DIFF
--- a/Arduino/MPU6050/MPU6050.cpp
+++ b/Arduino/MPU6050/MPU6050.cpp
@@ -37,6 +37,11 @@ THE SOFTWARE.
 
 #include "MPU6050.h"
 
+#ifndef BUFFER_LENGTH
+// band-aid fix for platforms without Wire-defined BUFFER_LENGTH (removed from some official implementations)
+#define BUFFER_LENGTH 32
+#endif
+
 /** Specific address constructor.
  * @param address I2C address, uses default I2C address if none is specified
  * @see MPU6050_DEFAULT_ADDRESS


### PR DESCRIPTION
Fixed compilation problem on Maixduino platform which lacks BUFFER_LENGTH by coping the workaround from I2Cdev.cpp