### PR TITLE
Fastwire I2C freq fix

### DIFF
--- a/Arduino/I2Cdev/I2Cdev.cpp
+++ b/Arduino/I2Cdev/I2Cdev.cpp
@@ -753,7 +753,7 @@ uint16_t I2Cdev::readTimeout = I2CDEV_DEFAULT_READ_TIMEOUT;
         #endif
 
         TWSR = 0; // no prescaler => prescaler = 1
-        TWBR = ((16000L / khz) - 16) / 2; // change the I2C clock rate
+        TWBR = F_CPU / 2000 / khz - 8; // change the I2C clock rate
         TWCR = 1 << TWEN; // enable twi module, no interrupt
     }
 


### PR DESCRIPTION
I noticed, that any read and write took 2 times as much time on 8 Mhz compared to 16 Mhz.
This PR fixes this issue and makes the I2C frequency F_CPU dependent.
Also saves 2 bytes in flash :)