### PR TITLE
Fix typos that prevent MP6050 library from compiling on Arduino

### DIFF
--- a/Arduino/MPU6050/MPU6050.cpp
+++ b/Arduino/MPU6050/MPU6050.cpp
@@ -3381,7 +3381,7 @@ int16_t * MPU6050_Base::GetActiveOffsets() {
         I2Cdev::readWords(devAddr, AOffsetRegister+6, 1, (uint16_t *)(Data+2), I2Cdev::readTimeout, wireObj);
     }
     I2Cdev::readWords(devAddr, 0x13, 3, (uint16_t *)(Data+3), I2Cdev::readTimeout, wireObj);
-    for(uint i = 0; i < 6; i++){
+    for(int i = 0; i < 6; i++){
         offsets[i] = Data[i];
     }
     return offsets;

--- a/Arduino/MPU6050/MPU6050.h
+++ b/Arduino/MPU6050/MPU6050.h
@@ -832,7 +832,7 @@ class MPU6050_Base {
 		void CalibrateAccel(uint8_t Loops = 15);// Fine tune after setting offsets with less Loops.
 		void PID(uint8_t ReadAddress, float kP,float kI, uint8_t Loops);  // Does the math
 		void PrintActiveOffsets(); // See the results of the Calibration
-		int16_t GetActiveOffsets();
+		int16_t* GetActiveOffsets();
 
     protected:
         uint8_t devAddr;


### PR DESCRIPTION
Fix the following issues throwing compilation errors with example code for Arduino:
- GetActiveOffsets() was mistakenly returning an int16 when it was written to return an int16*
- A for loop in GetActiveOffsets was using the uint type for its counter, which is not a standard C type; switched to an int