### PR TITLE
Bump library manifest version to 1.0.0

### DIFF
--- a/Arduino/AD7746/library.json
+++ b/Arduino/AD7746/library.json
@@ -1,5 +1,6 @@
 {
   "name": "I2Cdevlib-AD7746",
+  "version": "1.0.0",
   "keywords": "capacitance, converter, sensor, i2cdevlib, i2c",
   "description": "The AD7745/AD7746 are 24-Bit Capacitance-to-Digital Converter with Temperature Sensor",
   "include": "Arduino/AD7746",
@@ -10,8 +11,7 @@
   },
   "dependencies":
   {
-    "name": "I2Cdevlib-Core",
-    "frameworks": "arduino"
+    "jrowberg/I2Cdevlib-Core": "*"
   },
   "frameworks": "arduino",
   "platforms": "*"

--- a/Arduino/ADS1115/library.json
+++ b/Arduino/ADS1115/library.json
@@ -1,5 +1,6 @@
 {
   "name": "I2Cdevlib-ADS1115",
+  "version": "1.0.0",
   "keywords": "MUX, PGA, comparator, oscillator, reference, i2cdevlib, i2c",
   "description": "ADS1115 is 16-Bit ADC with Integrated MUX, PGA, Comparator, Oscillator, and Reference",
   "include": "Arduino/ADS1115",
@@ -10,8 +11,7 @@
   },
   "dependencies":
   {
-    "name": "I2Cdevlib-Core",
-    "frameworks": "arduino"
+    "jrowberg/I2Cdevlib-Core": "*"
   },
   "frameworks": "arduino",
   "platforms": "*"

--- a/Arduino/ADXL345/library.json
+++ b/Arduino/ADXL345/library.json
@@ -1,5 +1,6 @@
 {
   "name": "I2Cdevlib-ADXL345",
+  "version": "1.0.0",
   "keywords": "accelerometer, sensor, i2cdevlib, i2c",
   "description": "The ADXL345 is a small, thin, ultralow power, 3-axis accelerometer with high resolution (13-bit) measurement",
   "include": "Arduino/ADXL345",
@@ -10,8 +11,7 @@
   },
   "dependencies":
   {
-    "name": "I2Cdevlib-Core",
-    "frameworks": "arduino"
+    "jrowberg/I2Cdevlib-Core": "*"
   },
   "frameworks": "arduino",
   "platforms": "*"

--- a/Arduino/AK8963/library.json
+++ b/Arduino/AK8963/library.json
@@ -1,5 +1,6 @@
 {
   "name": "I2Cdevlib-AK8963",
+  "version": "1.0.0",
   "keywords": "compass, sensor, i2cdevlib, i2c",
   "description": "AK8963 is 3-axis electronic compass IC with high sensitive Hall sensor technology",
   "include": "Arduino/AK8963",
@@ -9,12 +10,9 @@
     "url": "https://github.com/jrowberg/i2cdevlib.git"
   },
   "dependencies":
-  [
-    {
-      "name": "I2Cdevlib-Core",
-      "frameworks": "arduino"
-    }
-  ],
+  {
+    "jrowberg/I2Cdevlib-Core": "*"
+  },
   "frameworks": "arduino",
   "platforms": "*"
 }

--- a/Arduino/AK8975/library.json
+++ b/Arduino/AK8975/library.json
@@ -1,5 +1,6 @@
 {
   "name": "I2Cdevlib-AK8975",
+  "version": "1.0.0",
   "keywords": "compass, sensor, i2cdevlib, i2c",
   "description": "AK8975 is 3-axis electronic compass IC with high sensitive Hall sensor technology",
   "include": "Arduino/AK8975",
@@ -9,16 +10,10 @@
     "url": "https://github.com/jrowberg/i2cdevlib.git"
   },
   "dependencies":
-  [
-    {
-      "name": "I2Cdevlib-Core",
-      "frameworks": "arduino"
-    },
-    {
-      "name": "I2Cdevlib-MPU6050",
-      "frameworks": "arduino"
-    }    
-  ],
+  {
+    "jrowberg/I2Cdevlib-Core": "*",
+    "jrowberg/I2Cdevlib-MPU6050": "*"
+  },  
   "frameworks": "arduino",
   "platforms": "*"
 }

--- a/Arduino/BMA150/library.json
+++ b/Arduino/BMA150/library.json
@@ -1,5 +1,6 @@
 {
   "name": "I2Cdevlib-BMA150",
+  "version": "1.0.0",
   "keywords": "accelerometer, sensor, i2cdevlib, i2c",
   "description": "The BMA150 is a triaxial, low-g acceleration sensor IC with digital output for consumer market applications",
   "include": "Arduino/BMA150",
@@ -10,8 +11,7 @@
   },
   "dependencies":
   {
-    "name": "I2Cdevlib-Core",
-    "frameworks": "arduino"
+    "jrowberg/I2Cdevlib-Core": "*"
   },
   "frameworks": "arduino",
   "platforms": "*"

--- a/Arduino/BMP085/library.json
+++ b/Arduino/BMP085/library.json
@@ -1,5 +1,6 @@
 {
   "name": "I2Cdevlib-BMP085",
+  "version": "1.0.0",
   "keywords": "altimeter, altitude, barometer, pressure, temperature, sensor, i2cdevlib, i2c",
   "description": "The BMP085 is barometric pressure, temperature and altitude sensor",
   "include": "Arduino/BMP085",
@@ -10,8 +11,7 @@
   },
   "dependencies":
   {
-    "name": "I2Cdevlib-Core",
-    "frameworks": "arduino"
+    "jrowberg/I2Cdevlib-Core": "*"
   },
   "frameworks": "arduino",
   "platforms": "*"

--- a/Arduino/DS1307/library.json
+++ b/Arduino/DS1307/library.json
@@ -1,5 +1,6 @@
 {
   "name": "I2Cdevlib-DS1307",
+  "version": "1.0.0",
   "keywords": "rtc, time, clock, i2cdevlib, i2c",
   "description": "The DS1307 serial real-time clock (RTC) is a low-power, full binary-coded decimal (BCD) clock/calendar plus 56 bytes of NV SRAM",
   "include": "Arduino/DS1307",
@@ -10,8 +11,7 @@
   },
   "dependencies":
   {
-    "name": "I2Cdevlib-Core",
-    "frameworks": "arduino"
+    "jrowberg/I2Cdevlib-Core": "*"
   },
   "frameworks": "arduino",
   "platforms": "*"

--- a/Arduino/HMC5843/library.json
+++ b/Arduino/HMC5843/library.json
@@ -1,5 +1,6 @@
 {
   "name": "I2Cdevlib-HMC5843",
+  "version": "1.0.0",
   "keywords": "magnetometer, compass, sensor, i2cdevlib, i2c",
   "description": "The HMC5843 is 3-Axis digital compass/magnetometer",
   "include": "Arduino/HMC5843",
@@ -10,8 +11,7 @@
   },
   "dependencies":
   {
-    "name": "I2Cdevlib-Core",
-    "frameworks": "arduino"
+    "jrowberg/I2Cdevlib-Core": "*"
   },
   "frameworks": "arduino",
   "platforms": "*"

--- a/Arduino/HMC5883L/library.json
+++ b/Arduino/HMC5883L/library.json
@@ -1,5 +1,6 @@
 {
   "name": "I2Cdevlib-HMC5883L",
+  "version": "1.0.0",
   "keywords": "magnetometer, compass, sensor, i2cdevlib, i2c",
   "description": "The HMC5883L is 3-Axis digital compass/magnetometer",
   "include": "Arduino/HMC5883L",
@@ -10,8 +11,7 @@
   },
   "dependencies":
   {
-    "name": "I2Cdevlib-Core",
-    "frameworks": "arduino"
+    "jrowberg/I2Cdevlib-Core": "*"
   },
   "frameworks": "arduino",
   "platforms": "*"

--- a/Arduino/HTU21D/library.json
+++ b/Arduino/HTU21D/library.json
@@ -1,5 +1,6 @@
 {
   "name": "I2Cdevlib-HTU21D”,
+  "version": "1.0.0",
   "keywords": “temperature, humidity, i2cdevlib, i2c",
   "description": "HTU21D is 12-Bit humidity and 14-bit temperature sensor",
   "include": "Arduino/HTU21D",
@@ -10,8 +11,7 @@
   },
   "dependencies":
   {
-    "name": "I2Cdevlib-Core",
-    "frameworks": "arduino"
+    "jrowberg/I2Cdevlib-Core": "*"
   },
   "frameworks": "arduino",
   "platforms": "*"

--- a/Arduino/I2Cdev/library.json
+++ b/Arduino/I2Cdev/library.json
@@ -1,5 +1,6 @@
 {
   "name": "I2Cdevlib-Core",
+  "version": "1.0.0",
   "keywords": "i2cdevlib, i2c",
   "description": "The I2C Device Library (I2Cdevlib) is a collection of uniform and well-documented classes to provide simple and intuitive interfaces to I2C devices.",
   "include": "Arduino/I2Cdev",
@@ -10,9 +11,7 @@
   },
   "frameworks": "arduino",
   "platforms": "*",
-   "dependencies": [
-     {
-        "name": "Wire"
-     }
-  ]
+  "dependencies": {
+    "Wire": "*"
+  }
 }

--- a/Arduino/IAQ2000/library.json
+++ b/Arduino/IAQ2000/library.json
@@ -1,5 +1,6 @@
 {
   "name": "I2Cdevlib-IAQ2000",
+  "version": "1.0.0",
   "keywords": "co2, carbon, dioxide, sensor, i2cdevlib, i2c",
   "description": "The iAQ-2000 Indoor Air Quality Module is a sensitive, low-cost solution for detecting poor air quality",
   "include": "Arduino/IAQ2000",
@@ -10,8 +11,7 @@
   },
   "dependencies":
   {
-    "name": "I2Cdevlib-Core",
-    "frameworks": "arduino"
+    "jrowberg/I2Cdevlib-Core": "*"
   },
   "frameworks": "arduino",
   "platforms": "*"

--- a/Arduino/ITG3200/library.json
+++ b/Arduino/ITG3200/library.json
@@ -1,5 +1,6 @@
 {
   "name": "I2Cdevlib-ITG3200",
+  "version": "1.0.0",
   "keywords": "gyroscope, sensor, i2cdevlib, i2c",
   "description": "The ITG-3200 is groundbreaking 3-axis, digital output MEMS gyroscope",
   "include": "Arduino/ITG3200",
@@ -10,8 +11,7 @@
   },
   "dependencies":
   {
-    "name": "I2Cdevlib-Core",
-    "frameworks": "arduino"
+    "jrowberg/I2Cdevlib-Core": "*"
   },
   "frameworks": "arduino",
   "platforms": "*"

--- a/Arduino/L3G4200D/library.json
+++ b/Arduino/L3G4200D/library.json
@@ -1,5 +1,6 @@
 {
   "name": "I2Cdevlib-L3G4200D",
+  "version": "1.0.0",
   "keywords": "accelerometer, sensor, i2cdevlib, i2c",
   "description": "The L3G4200D is a low-power three-axis angular rate sensor able to provide unprecedented stablility of zero rate level and sensitivity over temperature and time",
   "include": "Arduino/L3G4200D",
@@ -10,8 +11,7 @@
   },
   "dependencies":
   {
-    "name": "I2Cdevlib-Core",
-    "frameworks": "arduino"
+    "jrowberg/I2Cdevlib-Core": "*"
   },
   "frameworks": "arduino",
   "platforms": "*"

--- a/Arduino/LM73/library.json
+++ b/Arduino/LM73/library.json
@@ -1,5 +1,6 @@
 {
   "name": "I2Cdevlib-LM73",
+  "version": "1.0.0",
   "keywords": "temperature, sensor, i2cdevlib, i2c",
   "description": "The LM73 is an integrated, digital-output temperature sensor featuring an incremental Delta-Sigma ADC",
   "include": "Arduino/LM73",
@@ -10,8 +11,7 @@
   },
   "dependencies":
   {
-    "name": "I2Cdevlib-Core",
-    "frameworks": "arduino"
+    "jrowberg/I2Cdevlib-Core": "*"
   },
   "frameworks": "arduino",
   "platforms": "*"

--- a/Arduino/MPR121/library.json
+++ b/Arduino/MPR121/library.json
@@ -1,5 +1,6 @@
 {
   "name": "I2Cdevlib-MPR121",
+  "version": "1.0.0",
   "keywords": "touch, capacitance, proximity, sensor, i2cdevlib, i2c",
   "description": "The MPR121 is a 12-bit proximity capacitive touch sensor",
   "include": "Arduino/MPR121",
@@ -10,8 +11,7 @@
   },
   "dependencies":
   {
-    "name": "I2Cdevlib-Core",
-    "frameworks": "arduino"
+    "jrowberg/I2Cdevlib-Core": "*"
   },
   "frameworks": "arduino",
   "platforms": "*"

--- a/Arduino/MPU6050/library.json
+++ b/Arduino/MPU6050/library.json
@@ -1,5 +1,6 @@
 {
   "name": "I2Cdevlib-MPU6050",
+  "version": "1.0.0",
   "keywords": "gyroscope, accelerometer, sensor, i2cdevlib, i2c",
   "description": "The MPU6050 combines a 3-axis gyroscope and a 3-axis accelerometer on the same silicon die together with an onboard Digital Motion Processor(DMP) which processes complex 6-axis MotionFusion algorithms",
   "include": "Arduino/MPU6050",
@@ -10,8 +11,7 @@
   },
   "dependencies":
   {
-    "name": "I2Cdevlib-Core",
-    "frameworks": "arduino"
+    "jrowberg/I2Cdevlib-Core": "*"
   },
   "frameworks": "arduino",
   "platforms": "*"

--- a/Arduino/MPU9150/library.json
+++ b/Arduino/MPU9150/library.json
@@ -1,5 +1,6 @@
 {
   "name": "I2Cdevlib-MPU9150",
+  "version": "1.0.0",
   "keywords": "gyroscope, accelerometer, compass, sensor, i2cdevlib, i2c",
   "description": "The MPU-9150 combines two chips: the MPU-6050, which contains a 3-axis gyroscope, 3-axis accelerometer and the AK8975, a 3-axis digital compass",
   "include": "Arduino/MPU9150",
@@ -10,8 +11,7 @@
   },
   "dependencies":
   {
-    "name": "I2Cdevlib-Core",
-    "frameworks": "arduino"
+    "jrowberg/I2Cdevlib-Core": "*"
   },
   "frameworks": "arduino",
   "platforms": "*"

--- a/Arduino/SSD1308/library.json
+++ b/Arduino/SSD1308/library.json
@@ -1,5 +1,6 @@
 {
   "name": "I2Cdevlib-SSD1308",
+  "version": "1.0.0",
   "keywords": "oled, pled, display, driver, i2cdevlib, i2c",
   "description": "SSD1308 is a single-chip CMOS OLED/PLED driver with controller for organic / polymer light emitting diode dot-matrix graphic display system",
   "include": "Arduino/SSD1308",
@@ -10,8 +11,7 @@
   },
   "dependencies":
   {
-    "name": "I2Cdevlib-Core",
-    "frameworks": "arduino"
+    "jrowberg/I2Cdevlib-Core": "*"
   },
   "frameworks": "arduino",
   "platforms": "*"

--- a/Arduino/TCA6424A/library.json
+++ b/Arduino/TCA6424A/library.json
@@ -1,5 +1,6 @@
 {
   "name": "I2Cdevlib-TCA6424A",
+  "version": "1.0.0",
   "keywords": "io, expander, i2cdevlib, i2c",
   "description": "The TCA6424A is a low-voltage 24-Bit I2C and SMBus I/O expander with interrupt output, reset and configuration registers",
   "include": "Arduino/TCA6424A",
@@ -10,8 +11,7 @@
   },
   "dependencies":
   {
-    "name": "I2Cdevlib-Core",
-    "frameworks": "arduino"
+    "jrowberg/I2Cdevlib-Core": "*"
   },
   "frameworks": "arduino",
   "platforms": "*"

--- a/MSP430/AK8975/library.json
+++ b/MSP430/AK8975/library.json
@@ -1,5 +1,6 @@
 {
   "name": "I2Cdevlib-AK8975",
+  "version": "1.0.0",
   "keywords": "compass, sensor, i2cdevlib, i2c",
   "description": "AK8975 is 3-axis electronic compass IC with high sensitive Hall sensor technology",
   "include": "MSP430/AK8975",

--- a/MSP430/I2Cdev/library.json
+++ b/MSP430/I2Cdev/library.json
@@ -1,5 +1,6 @@
 {
   "name": "I2Cdevlib-Core",
+  "version": "1.0.0",
   "keywords": "i2cdevlib, i2c",
   "description": "The I2C Device Library (I2Cdevlib) is a collection of uniform and well-documented classes to provide simple and intuitive interfaces to I2C devices.",
   "include": "MSP430/I2Cdev",

--- a/MSP430/MPU6050/library.json
+++ b/MSP430/MPU6050/library.json
@@ -1,5 +1,6 @@
 {
   "name": "I2Cdevlib-MPU6050",
+  "version": "1.0.0",
   "keywords": "gyroscope, accelerometer, sensor, i2cdevlib, i2c",
   "description": "The MPU6050 combines a 3-axis gyroscope and a 3-axis accelerometer on the same silicon die together with an onboard Digital Motion Processor(DMP) which processes complex 6-axis MotionFusion algorithms",
   "include": "MSP430/MPU6050",


### PR DESCRIPTION
The original discussion https://community.platformio.org/t/library-header-not-found-installed-library-seems-to-be-empty/27841

The new PlatformIO Registry requires the "version" field. See https://registry.platformio.org/libraries/jrowberg/I2Cdevlib-Core