### PR TITLE
Corrected gravity constants for FIFO processing to match 2g values

### DIFF
--- a/Arduino/MPU6050/MPU6050_6Axis_MotionApps612.cpp
+++ b/Arduino/MPU6050/MPU6050_6Axis_MotionApps612.cpp
@@ -490,10 +490,10 @@ uint8_t MPU6050::dmpGetGyro(VectorInt16 *v, const uint8_t* packet) {
 // uint8_t MPU6050::dmpSetLinearAccelFilterCoefficient(float coef);
 // uint8_t MPU6050::dmpGetLinearAccel(long *data, const uint8_t* packet);
 uint8_t MPU6050::dmpGetLinearAccel(VectorInt16 *v, VectorInt16 *vRaw, VectorFloat *gravity) {
-    // get rid of the gravity component (+1g = +8192 in standard DMP FIFO packet, sensitivity is 2g)
-    v -> x = vRaw -> x - gravity -> x*8192;
-    v -> y = vRaw -> y - gravity -> y*8192;
-    v -> z = vRaw -> z - gravity -> z*8192;
+    // get rid of the gravity component (+1g = +16384 in standard DMP FIFO packet, sensitivity is 2g)
+    v -> x = vRaw -> x - gravity -> x*16384;
+    v -> y = vRaw -> y - gravity -> y*16384;
+    v -> z = vRaw -> z - gravity -> z*16384;
     return 0;
 }
 // uint8_t MPU6050::dmpGetLinearAccelInWorld(long *data, const uint8_t* packet);
@@ -510,7 +510,7 @@ uint8_t MPU6050::dmpGetLinearAccelInWorld(VectorInt16 *v, VectorInt16 *vReal, Qu
 // uint8_t MPU6050::dmpGetTemperature(long *data, const uint8_t* packet);
 // uint8_t MPU6050::dmpGetGravity(long *data, const uint8_t* packet);
 uint8_t MPU6050::dmpGetGravity(int16_t *data, const uint8_t* packet) {
-    /* +1g corresponds to +8192, sensitivity is 2g. */
+    /* +1g corresponds to +16384, sensitivity is 2g. */
     int16_t qI[4];
     uint8_t status = dmpGetQuaternion(qI, packet);
     data[0] = ((int32_t)qI[1] * qI[3] - (int32_t)qI[0] * qI[2]) / 16384;


### PR DESCRIPTION
Gravity was not consistent within `Arduino/MPU6050/MPU6050_6Axis_MotionApps612.cpp` 
After some careful testing, adjusting the constants in this function gives correct acceleration values.
fixes https://github.com/jrowberg/i2cdevlib/issues/656