### PR TITLE
Improve error handling.

### DIFF
--- a/RP2040/I2Cdev/I2Cdev.h
+++ b/RP2040/I2Cdev/I2Cdev.h
@@ -65,6 +65,9 @@ class I2Cdev {
         static bool writeBytes(uint8_t devAddr, uint8_t regAddr, uint8_t length, uint8_t *data);
         static bool writeWords(uint8_t devAddr, uint8_t regAddr, uint8_t length, uint16_t *data);
 
+        static int  read(uint8_t devAddr, uint8_t length, uint8_t* data, uint32_t timeout, bool keep = false);
+        static int  write(uint8_t devAddr, uint8_t length, uint8_t* data, bool keep = true);
+        static void displayError();
         static uint32_t readTimeout;
 
 };

--- a/RP2040/MPU6050/examples/mpu6050_DMP_V6.12/CMakeLists.txt
+++ b/RP2040/MPU6050/examples/mpu6050_DMP_V6.12/CMakeLists.txt
@@ -28,6 +28,7 @@ target_link_libraries(mpu6050_DMP_port pico_stdlib)
 
 # Add any user requested libraries
 target_link_libraries(mpu6050_DMP_port
+        pico_cyw43_arch_none     # we need for PICO W to access the GPIO, but we don't need anything else
         hardware_i2c
         pico_double
         )

--- a/RP2040/MPU6050/examples/mpu6050_calibration/CMakeLists.txt
+++ b/RP2040/MPU6050/examples/mpu6050_calibration/CMakeLists.txt
@@ -28,6 +28,7 @@ target_link_libraries(mpu6050_calibration pico_stdlib)
 
 # Add any user requested libraries
 target_link_libraries(mpu6050_calibration
+        pico_cyw43_arch_none     # we need for PICO W to access the GPIO, but we don't need anything else
         hardware_i2c
         )
 


### PR DESCRIPTION
    In case of error, the current version of  I2Cdev returns error code, but MPU6050.cpp olmost never checks the return code and provides no correction actions.

    This commit will indicate I2C error by blinking on board LED and , in effect, will stop execution of the current program.