### PR TITLE
change length parameter of I2C transactions and MPU6050_getFIFOBytes from 8 bits to 16 bits

### DIFF
--- a/STM32/I2Cdev.c
+++ b/STM32/I2Cdev.c
@@ -63,7 +63,7 @@ extern ARM_DRIVER_I2C I2CDev_Driver;
  * @param data 		Buffer to save data into
  * @return Status of read operation (0 = success, <0 = error)
  */
-int8_t I2Cdev_readBytes(uint8_t dev_addr, uint8_t reg_addr, uint8_t len, uint8_t *data) {
+int8_t I2Cdev_readBytes(uint8_t dev_addr, uint8_t reg_addr, uint16_t len, uint8_t *data) {
 	int8_t err = 0;
 	uint8_t reg_data[1] = {reg_addr};
 
@@ -97,7 +97,7 @@ int8_t 	I2Cdev_readByte(uint8_t dev_addr, uint8_t reg_addr, uint8_t *data) {
  * @param data 		Buffer to save data into
  * @return Status of read operation (true = success)
  */
-int8_t 	I2Cdev_readWords(uint8_t dev_addr, uint8_t reg_addr, uint8_t len, uint16_t *data) {
+int8_t 	I2Cdev_readWords(uint8_t dev_addr, uint8_t reg_addr, uint16_t len, uint16_t *data) {
 	int8_t err;
 	uint16_t bytes_num = len*2;
 
@@ -161,7 +161,7 @@ int8_t I2Cdev_readBit(uint8_t dev_addr, uint8_t reg_addr, uint8_t bitn, uint8_t 
  * @return Status of read operation (0 = success, <0 = error)
  */
 int8_t I2Cdev_readBits(uint8_t dev_addr, uint8_t reg_addr, uint8_t start_bit, 
-		uint8_t len, uint8_t *data) 
+		uint16_t len, uint8_t *data) 
 {
 	int8_t err;
 
@@ -203,7 +203,7 @@ int8_t 	I2Cdev_readBitW(uint8_t dev_addr, uint8_t reg_addr, uint8_t bit_n, uint1
  * @return Status of read operation (0 = success, <0 = error)
  */
 int8_t I2Cdev_readBitsW(uint8_t dev_addr, uint8_t reg_addr, uint8_t start_bit,
-		uint8_t len, uint16_t *data)
+		uint16_t len, uint16_t *data)
 {
     int8_t err;
     uint16_t w;
@@ -226,7 +226,7 @@ int8_t I2Cdev_readBitsW(uint8_t dev_addr, uint8_t reg_addr, uint8_t start_bit,
  * @param data 		Buffer to copy new data from
  * @return Status of operation (0 = success, <0 = error)
  */
-int8_t 	I2Cdev_writeBytes(uint8_t dev_addr, uint8_t reg_addr, uint8_t len, uint8_t *data) {
+int8_t 	I2Cdev_writeBytes(uint8_t dev_addr, uint8_t reg_addr, uint16_t len, uint8_t *data) {
 	int8_t err;
 	uint8_t ts_data[len+1];
 
@@ -276,7 +276,7 @@ int8_t 	I2Cdev_writeWord(uint8_t dev_addr, uint8_t reg_addr, uint16_t data) {
  * @param data 		Buffer to copy new data from
  * @return Status of operation (0 = success, <0 = error)
  */
-int8_t 	I2Cdev_writeWords(uint8_t dev_addr, uint8_t reg_addr, uint8_t len, uint16_t *data) {
+int8_t 	I2Cdev_writeWords(uint8_t dev_addr, uint8_t reg_addr, uint16_t len, uint16_t *data) {
 	uint16_t bytes_num = len*2+1;
 	uint8_t bytes[bytes_num];
 
@@ -342,7 +342,7 @@ int8_t 	I2Cdev_writeBitW(uint8_t dev_addr, uint8_t reg_addr, uint8_t bit_n, uint
  * @return Status of operation (0 = success, <0 = error)
  */
 int8_t I2Cdev_writeBits(uint8_t dev_addr, uint8_t reg_addr, uint8_t start_bit,
-		uint8_t len, uint8_t data)
+		uint16_t len, uint8_t data)
 {
     uint8_t b;
     int8_t err;
@@ -371,7 +371,7 @@ int8_t I2Cdev_writeBits(uint8_t dev_addr, uint8_t reg_addr, uint8_t start_bit,
  * @return Status of operation (0 = success, <0 = error)
  */
 int8_t I2Cdev_writeBitsW(uint8_t dev_addr, uint8_t reg_addr, uint8_t start_bit,
-		uint8_t len, uint16_t data)
+		uint16_t len, uint16_t data)
 {
     uint16_t w;
     int8_t err;

--- a/STM32/I2Cdev.h
+++ b/STM32/I2Cdev.h
@@ -41,21 +41,21 @@ THE SOFTWARE.
 
 int8_t 	I2Cdev_readBit(uint8_t devAddr, uint8_t regAddr, uint8_t bitNum, uint8_t *data);
 int8_t 	I2Cdev_readBitW(uint8_t devAddr, uint8_t regAddr, uint8_t bitNum, uint16_t *data);
-int8_t 	I2Cdev_readBits(uint8_t devAddr, uint8_t regAddr, uint8_t bitStart, uint8_t length, uint8_t *data);
-int8_t 	I2Cdev_readBitsW(uint8_t devAddr, uint8_t regAddr, uint8_t bitStart, uint8_t length, uint16_t *data);
+int8_t 	I2Cdev_readBits(uint8_t devAddr, uint8_t regAddr, uint8_t bitStart, uint16_t length, uint8_t *data);
+int8_t 	I2Cdev_readBitsW(uint8_t devAddr, uint8_t regAddr, uint8_t bitStart, uint16_t length, uint16_t *data);
 int8_t 	I2Cdev_readByte(uint8_t devAddr, uint8_t regAddr, uint8_t *data);
 int8_t 	I2Cdev_readWord(uint8_t devAddr, uint8_t regAddr, uint16_t *data);
-int8_t 	I2Cdev_readBytes(uint8_t devAddr, uint8_t regAddr, uint8_t length, uint8_t *data);
-int8_t 	I2Cdev_readWords(uint8_t devAddr, uint8_t regAddr, uint8_t length, uint16_t *data);
+int8_t 	I2Cdev_readBytes(uint8_t devAddr, uint8_t regAddr, uint16_t length, uint8_t *data);
+int8_t 	I2Cdev_readWords(uint8_t devAddr, uint8_t regAddr, uint16_t length, uint16_t *data);
 
 int8_t 	I2Cdev_writeBit(uint8_t devAddr, uint8_t regAddr, uint8_t bitNum, uint8_t data);
 int8_t 	I2Cdev_writeBitW(uint8_t devAddr, uint8_t regAddr, uint8_t bitNum, uint16_t data);
-int8_t 	I2Cdev_writeBits(uint8_t devAddr, uint8_t regAddr, uint8_t bitStart, uint8_t length, uint8_t data);
-int8_t 	I2Cdev_writeBitsW(uint8_t devAddr, uint8_t regAddr, uint8_t bitStart, uint8_t length, uint16_t data);
+int8_t 	I2Cdev_writeBits(uint8_t devAddr, uint8_t regAddr, uint8_t bitStart, uint16_t length, uint8_t data);
+int8_t 	I2Cdev_writeBitsW(uint8_t devAddr, uint8_t regAddr, uint8_t bitStart, uint16_t length, uint16_t data);
 int8_t 	I2Cdev_writeByte(uint8_t devAddr, uint8_t regAddr, uint8_t data);
 int8_t 	I2Cdev_writeWord(uint8_t devAddr, uint8_t regAddr, uint16_t data);
-int8_t 	I2Cdev_writeBytes(uint8_t devAddr, uint8_t regAddr, uint8_t length, uint8_t *data);
-int8_t 	I2Cdev_writeWords(uint8_t devAddr, uint8_t regAddr, uint8_t length, uint16_t *data);
+int8_t 	I2Cdev_writeBytes(uint8_t devAddr, uint8_t regAddr, uint16_t length, uint8_t *data);
+int8_t 	I2Cdev_writeWords(uint8_t devAddr, uint8_t regAddr, uint16_t length, uint16_t *data);
 
 
 #endif /* SRC_I2CDEVLIB_I2CDEV_H_ */

--- a/STM32/MPU6050/MPU6050.c
+++ b/STM32/MPU6050/MPU6050.c
@@ -2675,7 +2675,7 @@ uint8_t MPU6050_getFIFOByte() {
     I2Cdev_readByte(mpu6050.devAddr, MPU6050_RA_FIFO_R_W, mpu6050.buffer);
     return mpu6050.buffer[0];
 }
-void MPU6050_getFIFOBytes(uint8_t *data, uint8_t length) {
+void MPU6050_getFIFOBytes(uint8_t *data, uint16_t length) {
     I2Cdev_readBytes(mpu6050.devAddr, MPU6050_RA_FIFO_R_W, length, data);
 }
 /** Write byte to FIFO mpu6050.buffer.

--- a/STM32/MPU6050/MPU6050.h
+++ b/STM32/MPU6050/MPU6050.h
@@ -680,7 +680,7 @@ uint16_t MPU6050_getFIFOCount();
 // FIFO_R_W register
 uint8_t MPU6050_getFIFOByte();
 void MPU6050_setFIFOByte(uint8_t data);
-void MPU6050_getFIFOBytes(uint8_t *data, uint8_t length);
+void MPU6050_getFIFOBytes(uint8_t *data, uint16_t length);
 
 // WHO_AM_I register
 uint8_t MPU6050_getDeviceID();

--- a/STM32HAL/I2Cdev/I2Cdev.c
+++ b/STM32HAL/I2Cdev/I2Cdev.c
@@ -88,7 +88,7 @@ uint8_t I2Cdev_readBitW(uint8_t devAddr, uint8_t regAddr, uint8_t bitNum, uint16
  * @param timeout Optional read timeout in milliseconds (0 to disable, leave off to use default class value in I2Cdev_readTimeout)
  * @return Status of read operation (true = success)
  */
-uint8_t I2Cdev_readBits(uint8_t devAddr, uint8_t regAddr, uint8_t bitStart, uint8_t length, uint8_t *data, uint16_t timeout)
+uint8_t I2Cdev_readBits(uint8_t devAddr, uint8_t regAddr, uint8_t bitStart, uint16_t length, uint8_t *data, uint16_t timeout)
 {
     // 01101001 read byte
     // 76543210 bit numbers
@@ -115,7 +115,7 @@ uint8_t I2Cdev_readBits(uint8_t devAddr, uint8_t regAddr, uint8_t bitStart, uint
  * @param timeout Optional read timeout in milliseconds (0 to disable, leave off to use default class value in I2Cdev_readTimeout)
  * @return Status of read operation (1 = success, 0 = failure, -1 = timeout)
  */
-uint8_t I2Cdev_readBitsW(uint8_t devAddr, uint8_t regAddr, uint8_t bitStart, uint8_t length, uint16_t *data, uint16_t timeout)
+uint8_t I2Cdev_readBitsW(uint8_t devAddr, uint8_t regAddr, uint8_t bitStart, uint16_t length, uint16_t *data, uint16_t timeout)
 {
     // 1101011001101001 read byte
     // fedcba9876543210 bit numbers
@@ -166,7 +166,7 @@ uint8_t I2Cdev_readWord(uint8_t devAddr, uint8_t regAddr, uint16_t *data, uint16
  * @param timeout Optional read timeout in milliseconds (0 to disable, leave off to use default class value in I2Cdev_readTimeout)
  * @return Number of bytes read (-1 indicates failure)
  */
-uint8_t I2Cdev_readBytes(uint8_t devAddr, uint8_t regAddr, uint8_t length, uint8_t *data, uint16_t timeout)
+uint8_t I2Cdev_readBytes(uint8_t devAddr, uint8_t regAddr, uint16_t length, uint8_t *data, uint16_t timeout)
 {
     uint16_t tout = timeout > 0 ? timeout : I2CDEV_DEFAULT_READ_TIMEOUT;
 
@@ -183,7 +183,7 @@ uint8_t I2Cdev_readBytes(uint8_t devAddr, uint8_t regAddr, uint8_t length, uint8
  * @param timeout Optional read timeout in milliseconds (0 to disable, leave off to use default class value in I2Cdev_readTimeout)
  * @return Number of words read (-1 indicates failure)
  */
-uint8_t I2Cdev_readWords(uint8_t devAddr, uint8_t regAddr, uint8_t length, uint16_t *data, uint16_t timeout)
+uint8_t I2Cdev_readWords(uint8_t devAddr, uint8_t regAddr, uint16_t length, uint16_t *data, uint16_t timeout)
 {
     uint16_t tout = timeout > 0 ? timeout : I2CDEV_DEFAULT_READ_TIMEOUT;
 
@@ -232,7 +232,7 @@ uint16_t I2Cdev_writeBitW(uint8_t devAddr, uint8_t regAddr, uint8_t bitNum, uint
  * @param data Right-aligned value to write
  * @return Status of operation (true = success)
  */
-uint16_t I2Cdev_writeBits(uint8_t devAddr, uint8_t regAddr, uint8_t bitStart, uint8_t length, uint8_t data)
+uint16_t I2Cdev_writeBits(uint8_t devAddr, uint8_t regAddr, uint8_t bitStart, uint16_t length, uint8_t data)
 {
     //      010 value to write
     // 76543210 bit numbers
@@ -265,7 +265,7 @@ uint16_t I2Cdev_writeBits(uint8_t devAddr, uint8_t regAddr, uint8_t bitStart, ui
  * @param data Right-aligned value to write
  * @return Status of operation (true = success)
  */
-uint16_t I2Cdev_writeBitsW(uint8_t devAddr, uint8_t regAddr, uint8_t bitStart, uint8_t length, uint16_t data)
+uint16_t I2Cdev_writeBitsW(uint8_t devAddr, uint8_t regAddr, uint8_t bitStart, uint16_t length, uint16_t data)
 {
     //              010 value to write
     // fedcba9876543210 bit numbers
@@ -319,7 +319,7 @@ uint16_t I2Cdev_writeWord(uint8_t devAddr, uint8_t regAddr, uint16_t data)
  * @param data Buffer to copy new data from
  * @return Status of operation (true = success)
  */
-uint16_t I2Cdev_writeBytes(uint8_t devAddr, uint8_t regAddr, uint8_t length, uint8_t* pData)
+uint16_t I2Cdev_writeBytes(uint8_t devAddr, uint8_t regAddr, uint16_t length, uint8_t* pData)
 {
     HAL_StatusTypeDef status = HAL_I2C_Mem_Write(I2Cdev_hi2c, devAddr << 1, regAddr, I2C_MEMADD_SIZE_8BIT, pData, length, 1000);
     return status == HAL_OK;
@@ -332,7 +332,7 @@ uint16_t I2Cdev_writeBytes(uint8_t devAddr, uint8_t regAddr, uint8_t length, uin
  * @param data Buffer to copy new data from
  * @return Status of operation (true = success)
  */
-uint16_t I2Cdev_writeWords(uint8_t devAddr, uint8_t regAddr, uint8_t length, uint16_t* pData)
+uint16_t I2Cdev_writeWords(uint8_t devAddr, uint8_t regAddr, uint16_t length, uint16_t* pData)
 {
     HAL_StatusTypeDef status = HAL_I2C_Mem_Write(I2Cdev_hi2c, devAddr << 1, regAddr, I2C_MEMADD_SIZE_8BIT, (uint8_t *)pData, sizeof(uint16_t) * length, 1000);
     return status == HAL_OK;

--- a/STM32HAL/I2Cdev/I2Cdev.h
+++ b/STM32HAL/I2Cdev/I2Cdev.h
@@ -56,20 +56,20 @@ void I2Cdev_init(I2C_HandleTypeDef * hi2c);
 
 uint8_t I2Cdev_readBit(uint8_t devAddr, uint8_t regAddr, uint8_t bitNum, uint8_t *data, uint16_t timeout);
 uint8_t I2Cdev_readBitW(uint8_t devAddr, uint8_t regAddr, uint8_t bitNum, uint16_t *data, uint16_t timeout);
-uint8_t I2Cdev_readBits(uint8_t devAddr, uint8_t regAddr, uint8_t bitStart, uint8_t length, uint8_t *data, uint16_t timeout);
-uint8_t I2Cdev_readBitsW(uint8_t devAddr, uint8_t regAddr, uint8_t bitStart, uint8_t length, uint16_t *data, uint16_t timeout);
+uint8_t I2Cdev_readBits(uint8_t devAddr, uint8_t regAddr, uint8_t bitStart, uint16_t length, uint8_t *data, uint16_t timeout);
+uint8_t I2Cdev_readBitsW(uint8_t devAddr, uint8_t regAddr, uint8_t bitStart, uint16_t length, uint16_t *data, uint16_t timeout);
 uint8_t I2Cdev_readByte(uint8_t devAddr, uint8_t regAddr, uint8_t *data, uint16_t timeout);
 uint8_t I2Cdev_readWord(uint8_t devAddr, uint8_t regAddr, uint16_t *data, uint16_t timeout);
-uint8_t I2Cdev_readBytes(uint8_t devAddr, uint8_t regAddr, uint8_t length, uint8_t *data, uint16_t timeout);
-uint8_t I2Cdev_readWords(uint8_t devAddr, uint8_t regAddr, uint8_t length, uint16_t *data, uint16_t timeout);
+uint8_t I2Cdev_readBytes(uint8_t devAddr, uint8_t regAddr, uint16_t length, uint8_t *data, uint16_t timeout);
+uint8_t I2Cdev_readWords(uint8_t devAddr, uint8_t regAddr, uint16_t length, uint16_t *data, uint16_t timeout);
 
 uint16_t I2Cdev_writeBit(uint8_t devAddr, uint8_t regAddr, uint8_t bitNum, uint8_t data);
 uint16_t I2Cdev_writeBitW(uint8_t devAddr, uint8_t regAddr, uint8_t bitNum, uint16_t data);
-uint16_t I2Cdev_writeBits(uint8_t devAddr, uint8_t regAddr, uint8_t bitStart, uint8_t length, uint8_t data);
-uint16_t I2Cdev_writeBitsW(uint8_t devAddr, uint8_t regAddr, uint8_t bitStart, uint8_t length, uint16_t data);
+uint16_t I2Cdev_writeBits(uint8_t devAddr, uint8_t regAddr, uint8_t bitStart, uint16_t length, uint8_t data);
+uint16_t I2Cdev_writeBitsW(uint8_t devAddr, uint8_t regAddr, uint8_t bitStart, uint16_t length, uint16_t data);
 uint16_t I2Cdev_writeByte(uint8_t devAddr, uint8_t regAddr, uint8_t data);
 uint16_t I2Cdev_writeWord(uint8_t devAddr, uint8_t regAddr, uint16_t data);
-uint16_t I2Cdev_writeBytes(uint8_t devAddr, uint8_t regAddr, uint8_t length, uint8_t *data);
-uint16_t I2Cdev_writeWords(uint8_t devAddr, uint8_t regAddr, uint8_t length, uint16_t *data);
+uint16_t I2Cdev_writeBytes(uint8_t devAddr, uint8_t regAddr, uint16_t length, uint8_t *data);
+uint16_t I2Cdev_writeWords(uint8_t devAddr, uint8_t regAddr, uint16_t length, uint16_t *data);
 
 #endif /* _I2CDEV_H_ */


### PR DESCRIPTION
Change type of length parameter from uint8_t to uint16_t for the following functions (STM32 and STM32HAL):
		I2Cdev_readBits, I2Cdev_readBitsW,
		I2Cdev_readBytes, I2Cdev_readWords,
		I2Cdev_writeBits, I2Cdev_writeBitsW,
		I2Cdev_writeBytes, I2Cdev_writeWords
to allow transactions longer than 255 bytes.

Change length parameter of MPU6050_getFIFOBytes from u8 to u16 to allow transactions longer than 255 bytes.