### PR TITLE
Update I2Cdev.h

### DIFF
--- a/STM32HAL/I2Cdev/I2Cdev.h
+++ b/STM32HAL/I2Cdev/I2Cdev.h
@@ -47,7 +47,7 @@ typedef int bool;
 #define true 1
 #define false 0
 
-uint16_t I2Cdev_readTimeout;
+extern uint16_t I2Cdev_readTimeout;
 
 // 1000ms default read timeout (modify with "I2Cdev::readTimeout = [ms];")
 #define I2CDEV_DEFAULT_READ_TIMEOUT     1000


### PR DESCRIPTION
For Build Error. It gives a build error due to being defined in both C and H files. The problem can be eliminated by externing the variable in the h file.