### PR TITLE
Fix RP2040 example CMakeLists.txt files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ PIC18/MPU6050/Examples/MPU6050_raw.X/build/
 /dsPIC30F/MPU6050/Examples/MPU6050_example.X/dist/default/
 ESP32_ESP-IDF/build/
 ESP32_ESP-IDF/sdkconfig
+/RP2040/MPU6050/examples/mpu6050_calibration
+/RP2040/MPU6050/examples/mpu6050_DMP_V6.12

--- a/RP2040/MPU6050/examples/mpu6050_DMP_V6.12/CMakeLists.txt
+++ b/RP2040/MPU6050/examples/mpu6050_DMP_V6.12/CMakeLists.txt
@@ -17,8 +17,13 @@ pico_sdk_init()
 
 add_executable(mpu6050_DMP_port 
          mpu6050_DMP_port.cpp 
-         MPU6050.cpp
-         I2Cdev.cpp
+         ../../MPU6050.cpp
+         ../../../I2Cdev/I2Cdev.cpp
+        )
+
+target_include_directories(mpu6050_DMP_port PRIVATE
+         ${CMAKE_CURRENT_LIST_DIR}/../../
+         ${CMAKE_CURRENT_LIST_DIR}/../../../I2Cdev
         )
 
 # Add any user requested libraries

--- a/RP2040/MPU6050/examples/mpu6050_calibration/CMakeLists.txt
+++ b/RP2040/MPU6050/examples/mpu6050_calibration/CMakeLists.txt
@@ -17,8 +17,13 @@ pico_sdk_init()
 
 add_executable( mpu6050_calibration
          mpu6050_calibration.cpp 
-         MPU6050.cpp
-         I2Cdev.cpp
+         ../../MPU6050.cpp
+         ../../../I2Cdev/I2Cdev.cpp
+        )
+
+target_include_directories(mpu6050_calibration PRIVATE
+         ${CMAKE_CURRENT_LIST_DIR}/../../
+         ${CMAKE_CURRENT_LIST_DIR}/../../../I2Cdev
         )
 
 # Add any user requested libraries


### PR DESCRIPTION
The paths to the I2Cdev and MPU6050 classes are wrong, fix them so that RP2040 examples can be built. Also, add the build directories for the examples to the project's .gitignore file.